### PR TITLE
Add support for building Apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,10 +42,11 @@ Additional requirements for `build.sh`:
 The `packager` (`bap-builder`) has these commands:
  - `build-image` for building Docker images
  - `build-package` for building Packages
+ - `build-app` for building Apps
  - `create-sysroot` for creating sysroot from already built Packages
 
-The `build-package` and `create-sysroot` commands are using Git Repository as storage for built
-Packages. Given Git Repository must be created before usage.
+The `build-package`, `build-app` and `create-sysroot` commands are using Git Repository as storage
+for built Packages. Given Git Repository must be created before usage.
 
 **NOTE:** Detailed use case scenarios is decribed in [UseCaseScenarios](./doc/UseCaseScenarios.md) document.
 

--- a/bap-builder/AppMode.go
+++ b/bap-builder/AppMode.go
@@ -1,0 +1,119 @@
+package main
+
+import (
+	"bringauto/modules/bringauto_const"
+	"bringauto/modules/bringauto_context"
+	"bringauto/modules/bringauto_log"
+	"bringauto/modules/bringauto_package"
+	"bringauto/modules/bringauto_prerequisites"
+	"bringauto/modules/bringauto_process"
+	"bringauto/modules/bringauto_repository"
+	"bringauto/modules/bringauto_sysroot"
+	"fmt"
+)
+
+// BuildApp
+func BuildApp(cmdLine *BuildAppCmdLineArgs, contextPath string) error {
+	platformString, err := determinePlatformString(*cmdLine.DockerImageName)
+	if err != nil {
+		return err
+	}
+	repo := bringauto_repository.GitLFSRepository{
+		GitRepoPath: *cmdLine.OutputDir,
+	}
+	err = bringauto_prerequisites.Initialize(&repo)
+	if err != nil {
+		return err
+	}
+	err = performPreBuildChecks(contextPath, &repo, platformString, *cmdLine.DockerImageName)
+	if err != nil {
+		return err
+	}
+
+	handleRemover := bringauto_process.SignalHandlerAddHandler(repo.RestoreAllChanges)
+	defer handleRemover()
+	if *cmdLine.All {
+		err = buildAllApps(*cmdLine.DockerImageName, contextPath, platformString, repo)
+	} else {
+		err = buildSingleApp(cmdLine, contextPath, platformString, repo)
+	}
+	if err != nil {
+		return err
+	}
+	err = repo.CommitAllChanges()
+	return err
+}
+
+// buildAllApps
+// Builds all Apps specified in contextPath. Returns nil if everything is ok, else returns error.
+func buildAllApps(
+	imageName      string,
+	contextPath    string,
+	platformString *bringauto_package.PlatformString,
+	repo           bringauto_repository.GitLFSRepository,
+) error {
+	contextManager := bringauto_context.ContextManager{
+		ContextPath: contextPath,
+	}
+	appJsonPathMap, err := contextManager.GetAllConfigJsonPaths(bringauto_const.AppDirName)
+	if err != nil {
+		return err
+	}
+
+	defsMap := make(ConfigMapType)
+	for _, appJsonPathList := range appJsonPathMap {
+		addConfigsToDefsMap(&defsMap, appJsonPathList)
+	}
+
+	logger := bringauto_log.GetLogger()
+
+	count := int32(0)
+	for appName := range defsMap {
+		for _, config := range defsMap[appName] {
+			buildConfigs := config.GetBuildStructure(imageName, platformString)
+			if len(buildConfigs) == 0 {
+				continue
+			}
+			count++
+			err = buildAndCopyPackage(&buildConfigs, platformString, repo, bringauto_const.AppDirName)
+			if err != nil {
+				return fmt.Errorf("cannot build App '%s' - %s", config.Package.Name, err)
+			}
+		}
+		bringauto_sysroot.RemoveInstallSysroot()
+	}
+	if count == 0 {
+		logger.Warn("Nothing to build. Did you enter correct image name?")
+	}
+
+	return nil
+}
+
+// buildSingleApp
+// Builds single App specified by name in cmdLine. Returns nil if everything is ok, else returns error.
+func buildSingleApp(
+	cmdLine        *BuildAppCmdLineArgs,
+	contextPath    string,
+	platformString *bringauto_package.PlatformString,
+	repo           bringauto_repository.GitLFSRepository,
+) error {
+	contextManager := bringauto_context.ContextManager{
+		ContextPath: contextPath,
+	}
+
+	configList, err := prepareConfigsNoBuildDeps(*cmdLine.Name, &contextManager, bringauto_const.AppDirName)
+	if err != nil {
+		return err
+	}
+	if len(configList) == 0 {
+		return fmt.Errorf("nothing to build")
+	}
+	for _, config := range configList {
+		buildConfigs := config.GetBuildStructure(*cmdLine.DockerImageName, platformString)
+		err = buildAndCopyPackage(&buildConfigs, platformString, repo, bringauto_const.AppDirName)
+		if err != nil {
+			return fmt.Errorf("cannot build package '%s' - %s", *cmdLine.Name, err)
+		}
+	}
+	return nil
+}

--- a/bap-builder/AppMode.go
+++ b/bap-builder/AppMode.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bringauto/modules/bringauto_config"
 	"bringauto/modules/bringauto_const"
 	"bringauto/modules/bringauto_context"
 	"bringauto/modules/bringauto_log"
@@ -70,6 +71,9 @@ func buildAllApps(
 	count := int32(0)
 	for appName := range defsMap {
 		for _, config := range defsMap[appName] {
+			if isDepsInConfig(config) {
+				return fmt.Errorf("App has non-empty DependsOn")
+			}
 			buildConfigs := config.GetBuildStructure(imageName, platformString)
 			if len(buildConfigs) == 0 {
 				continue
@@ -109,6 +113,9 @@ func buildSingleApp(
 		return fmt.Errorf("nothing to build")
 	}
 	for _, config := range configList {
+		if isDepsInConfig(config) {
+			return fmt.Errorf("App has non-empty DependsOn")
+		}
 		buildConfigs := config.GetBuildStructure(*cmdLine.DockerImageName, platformString)
 		err = buildAndCopyPackage(&buildConfigs, platformString, repo, bringauto_const.AppDirName)
 		if err != nil {
@@ -116,4 +123,10 @@ func buildSingleApp(
 		}
 	}
 	return nil
+}
+
+// isDepsInConfig
+// Returns true if given config has non-empty DependsOn array, else returns false.
+func isDepsInConfig(config *bringauto_config.Config) bool {
+	return len(config.DependsOn) > 0
 }

--- a/bap-builder/AppMode.go
+++ b/bap-builder/AppMode.go
@@ -84,7 +84,10 @@ func buildAllApps(
 				return fmt.Errorf("cannot build App '%s' - %s", config.Package.Name, err)
 			}
 		}
-		bringauto_sysroot.RemoveInstallSysroot()
+		err = bringauto_sysroot.RemoveInstallSysroot()
+		if err != nil {
+			return fmt.Errorf("cannot remove install sysroot directory")
+		}
 	}
 	if count == 0 {
 		logger.Warn("Nothing to build. Did you enter correct image name?")

--- a/bap-builder/SysrootMode.go
+++ b/bap-builder/SysrootMode.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bringauto/modules/bringauto_const"
 	"bringauto/modules/bringauto_context"
 	"bringauto/modules/bringauto_log"
 	"bringauto/modules/bringauto_package"
@@ -69,7 +70,7 @@ func CreateSysroot(cmdLine *CreateSysrootCmdLineArgs, contextPath string) error 
 func unzipAllPackagesToDir(packages []bringauto_package.Package, repo *bringauto_repository.GitLFSRepository, dirPath string) error {
 	anyPackageCopied := false
 	for _, pack := range packages {
-		packPath := path.Join(repo.CreatePackagePath(pack), pack.GetFullPackageName() + bringauto_package.ZipExt)
+		packPath := path.Join(repo.CreatePath(pack, bringauto_const.PackageDirName), pack.GetFullPackageName() + bringauto_package.ZipExt)
 		_, err := os.Stat(packPath)
 		if err == nil { // Package exists in Git Lfs
 			var sysrootPath string

--- a/bap-builder/main.go
+++ b/bap-builder/main.go
@@ -39,7 +39,14 @@ func main() {
 		}
 		return
 	}
-
+	if args.BuildApp {
+		err = BuildApp(&args.BuildAppArgs, *args.Context)
+		if err != nil {
+			logger.Error("Failed to build App: %s", err)
+			return
+		}
+		return
+	}
 	if args.CreateSysroot {
 		err = CreateSysroot(&args.CreateSysrootArgs, *args.Context)
 		if err != nil {

--- a/doc/BuildProcess.md
+++ b/doc/BuildProcess.md
@@ -1,7 +1,7 @@
 
 # Build Process
 
-Each Package has a Config file in the JSON format (Config file details in [Context Structure]).
+Each Package/App has a Config file in the JSON format (Config file details in [Context Structure]).
 
 ## Build All Packages
 

--- a/doc/ConfigStructure.md
+++ b/doc/ConfigStructure.md
@@ -12,7 +12,7 @@ Not all fields are required, and some fields have default values.
     "ENV_A": "Value A",
     "ENV_B": "Value B"
   },
-  "DependsOn": [ // List of external dependencies required for this project
+  "DependsOn": [ // List of external dependencies required for this project, for Apps must be empty
     "protobuf",
     "fleet-protocol-interface",
     "zlib"

--- a/doc/ContextStructure.md
+++ b/doc/ContextStructure.md
@@ -4,7 +4,7 @@
 Context structure is a directory structure that gathers Configs needed for BAP to
 work.
 
-In the Context the definitions of Packages (Configs) and Docker images are stored.
+In the Context the definitions of Packages/Apps (Configs) and Docker images are stored.
 
 ``` plaintext
 <context_directory>/
@@ -13,6 +13,12 @@ In the Context the definitions of Packages (Configs) and Docker images are store
    Dockerfile
   ...
  package/
+  <package_group_name>/
+   <package_config_a>.json
+   <package_config_b>.json
+   ...
+  ...
+ app/
   <package_group_name>/
    <package_config_a>.json
    <package_config_b>.json

--- a/doc/PackageRepository.md
+++ b/doc/PackageRepository.md
@@ -1,37 +1,38 @@
 # Package Repository
 
-The Package Repository (or Git Lfs) is used for storage of built Packages. It is a git repository
-at the same time. The git tool is used for managing consistent storage of Packages.
+The Package Repository (or Git Lfs) is used for storage of built Packages/Apps. It is a git repository
+at the same time. The git tool is used for managing consistent storage of Packages/Apps.
 
 ## Behaviour
 
 ### Package Repository consistency check
 
-At the start of `build-package` and `create-sysroot` commands the Package Repository consistency
-check is performed. The check consists of these steps:
+At the start of `build-package`, `build-app` and `create-sysroot` commands the Package Repository
+consistency check is performed. The check consists of these steps:
 
 1) Git status check
    - If the git status in Package Repository is not empty, the state of Repository is considered as
    non-consistent and the script ends with error. The user should then clean the Repository and
    continue. It is a bug if the non-consistent state is caused by `bap-builder` itself.
-2) Comparing Configs currently in Context and built Packages in Package Repository
-   - If in Package Repository there is any version of Package which is not in Context, the Package
-   Repository is considered as non-consistent and the script ends with error. User needs to fix
-   this problem manually and then continue.
-   - If some Packages are in Context and are not in Package Repository, only warning is printed.
-     
-All files in `<DISTRO_NAME>/<DISTRO_VERSION/MACHINE_TYPE>` are checked, so any other files in this
-directory (alongside Package directories) will be counted as an error. User can't add any files
-here manually.
+2) Comparing Configs currently in Context and built Packages/Apps in Package Repository
+   - If in Package Repository there is any version of Package/App which is not in Context, the
+   Package Repository is considered as non-consistent and the script ends with error. User needs to
+   fix this problem manually and then continue.
+   - If some Packages/Apps are in Context and are not in Package Repository, only warning is
+   printed.
+
+All files in `(app|package)/<DISTRO_NAME>/<DISTRO_VERSION/MACHINE_TYPE>` are checked, so any other
+files in this directory (alongside Package directories) will be counted as an error. User can't add
+any files here manually.
 
 ### Managing Packages in Package Repository
 
 Following rules ans mechanisms ensures that the Package Repository is always consistent.
 
-- Each succesfully built Package by `build-package` command is copied to Package Repository
-(specified by cli flag) to specific path -
+- Each succesfully built Package/App by `build-package`/`build-app` command is copied to Package
+Repository (specified by cli flag) to specific path -
 `<DISTRO_NAME>/<DISTRO_VERSION/MACHINE_TYPE/PACKAGE_NAME>`
-- After all Packages are succesfully built, all copied files in Package Repository are git
+- After all Packages/Apps are succesfully built, all copied files in Package Repository are git
 committed and remain in Repository
-- If any build fails or the script is interrupted, all copied Packages are removed from
+- If any build fails or the script is interrupted, all copied Packages/Apps are removed from
 Repository

--- a/doc/Sysroot.md
+++ b/doc/Sysroot.md
@@ -8,10 +8,10 @@ introduced to BAP.
 
 ## Sysroot consistency mechanisms
 
-- At the start of `build-package` command the both debug and release sysroots are checked. If it
-isn't empty, the warning is printed.
+- At the start of `build-package` and `build-app` command the both debug and release sysroots are
+checked. If it isn't empty, the warning is printed.
 
-- During Package builds, the Package build files are copied to the sysroot directory
+- During Package/App builds, the Package/App build files are copied to the sysroot directory
 (`install_sysroot`). If any of the file is already present in the sysroot, the error is printed
 that the Package tries to overwrite files in sysroot, which would corrupt consistency of sysroot
 directory. If Package doesn't try to overwrite any files, the build proceeds and Package files are
@@ -25,11 +25,13 @@ with its dependencies are already in sysroot. If it is not (the Package is not i
 files are copied to new sysroot directory. Because of the sysroot consistency mechanism this new
 sysroot will also be consistent.
 
+- When `build-app` command with `--all` option is used, the sysroot directory is deleted after each
+build (with Apps the sysroot does not have to be shared between builds). If single App is being
+build, the sysroot is not deleted so the user can check the sysroot after build.
+
 ## Notes
 
 - The `install_sysroot` directory is not being deleted at the end of BAP execution (for a backup
 reason). If the user wants to build the same Packages again, it is a common practice to delete this
 directory manually. If it is not deleted and same Packages are build, the build obviously fails
 because same Package wants to overwrite its own files, which are already present in sysroot.
-
-

--- a/doc/UseCaseScenarios.md
+++ b/doc/UseCaseScenarios.md
@@ -292,6 +292,41 @@ packager build-package
   --output ./git-lfs-repo
 ```
 
+## Build App
+
+For apps which manages their own dependencies (e. g. using CMake), the Packager supports different
+workflow - Apps. The Configs for these Apps are in `app` directory in Context and are the same as
+for regular Packages with one exception - DependsOn array must be empty. The Apps do not support
+any dependencies managed by Packager, if the user needs it, the Packages should be used. Building
+Apps also do not support any dependency related flags (`--build-deps`, `--build-deps-on` ...).
+
+### Build App - all Apps
+
+Build all Apps in Context.
+
+**Command**
+
+```bash
+packager build-app
+  --context ./example \
+  --image-name debian \
+  --all \
+  --output ./git-lfs-repo
+```
+
+### Build App - single App
+
+Build single App in Context.
+
+**Command**
+
+```bash
+packager build-app
+  --context ./example \
+  --image-name debian \
+  --name app-name \
+  --output ./git-lfs-repo
+```
 
 ## Create Sysroot
 

--- a/example/app/io-module/io-module_debug.json
+++ b/example/app/io-module/io-module_debug.json
@@ -1,0 +1,35 @@
+{
+  "Env": {},
+  "Git": {
+    "URI": "https://github.com/bringauto/io-module.git",
+    "Revision": "v1.3.1"
+  },
+  "Build": {
+    "CMake": {
+      "Defines": {
+        "CMAKE_BUILD_TYPE": "Debug",
+        "BRINGAUTO_INSTALL": "ON"
+      }
+    }
+  },
+  "Package": {
+    "Name": "io-module",
+    "VersionTag": "v1.3.1",
+    "PlatformString": {
+      "Mode": "auto"
+    },
+    "IsLibrary": false,
+    "IsDevLib": false,
+    "IsDebug": true
+  },
+  "DockerMatrix": {
+    "ImageNames": [
+      "fleet-os-2",
+      "ubuntu2204",
+      "debian12",
+      "ubuntu2404",
+      "fedora40",
+      "fedora41"
+    ]
+  }
+}

--- a/example/app/io-module/io-module_release.json
+++ b/example/app/io-module/io-module_release.json
@@ -1,0 +1,35 @@
+{
+  "Env": {},
+  "Git": {
+    "URI": "https://github.com/bringauto/io-module.git",
+    "Revision": "v1.3.1"
+  },
+  "Build": {
+    "CMake": {
+      "Defines": {
+        "CMAKE_BUILD_TYPE": "Release",
+        "BRINGAUTO_INSTALL": "ON"
+      }
+    }
+  },
+  "Package": {
+    "Name": "io-module",
+    "VersionTag": "v1.3.1",
+    "PlatformString": {
+      "Mode": "auto"
+    },
+    "IsLibrary": false,
+    "IsDevLib": false,
+    "IsDebug": false
+  },
+  "DockerMatrix": {
+    "ImageNames": [
+      "fleet-os-2",
+      "ubuntu2204",
+      "debian12",
+      "ubuntu2404",
+      "fedora40",
+      "fedora41"
+    ]
+  }
+}

--- a/example/app/mission-module/mission-module_debug.json
+++ b/example/app/mission-module/mission-module_debug.json
@@ -1,0 +1,35 @@
+{
+  "Env": {},
+  "Git": {
+    "URI": "https://github.com/bringauto/mission-module.git",
+    "Revision": "v1.2.11"
+  },
+  "Build": {
+    "CMake": {
+      "Defines": {
+        "CMAKE_BUILD_TYPE": "Debug",
+        "BRINGAUTO_INSTALL": "ON"
+      }
+    }
+  },
+  "Package": {
+    "Name": "mission-module",
+    "VersionTag": "v1.2.11",
+    "PlatformString": {
+      "Mode": "auto"
+    },
+    "IsLibrary": false,
+    "IsDevLib": false,
+    "IsDebug": true
+  },
+  "DockerMatrix": {
+    "ImageNames": [
+      "fleet-os-2",
+      "ubuntu2204",
+      "debian12",
+      "ubuntu2404",
+      "fedora40",
+      "fedora41"
+    ]
+  }
+}

--- a/example/app/mission-module/mission-module_release.json
+++ b/example/app/mission-module/mission-module_release.json
@@ -1,0 +1,35 @@
+{
+  "Env": {},
+  "Git": {
+    "URI": "https://github.com/bringauto/mission-module.git",
+    "Revision": "v1.2.11"
+  },
+  "Build": {
+    "CMake": {
+      "Defines": {
+        "CMAKE_BUILD_TYPE": "Release",
+        "BRINGAUTO_INSTALL": "ON"
+      }
+    }
+  },
+  "Package": {
+    "Name": "mission-module",
+    "VersionTag": "v1.2.11",
+    "PlatformString": {
+      "Mode": "auto"
+    },
+    "IsLibrary": false,
+    "IsDevLib": false,
+    "IsDebug": false
+  },
+  "DockerMatrix": {
+    "ImageNames": [
+      "fleet-os-2",
+      "ubuntu2204",
+      "debian12",
+      "ubuntu2404",
+      "fedora40",
+      "fedora41"
+    ]
+  }
+}

--- a/modules/bringauto_const/Const.go
+++ b/modules/bringauto_const/Const.go
@@ -14,4 +14,6 @@ const (
 	DockerDirName  = "docker"
 	// Name of the package directory
 	PackageDirName = "package"
+	// Name of the app directory
+	AppDirName = "app"
 )

--- a/modules/bringauto_context/default_test.go
+++ b/modules/bringauto_context/default_test.go
@@ -52,9 +52,9 @@ func TestGetAllPackagesJsonDefPaths(t *testing.T) {
 		ContextPath: Set1DirPath,
 	}
 
-	jsonPaths, err := context.GetAllPackagesJsonDefPaths()
+	jsonPaths, err := context.GetAllConfigJsonPaths(bringauto_const.PackageDirName)
 	if err != nil {
-		t.Fatalf("GetAllPackagesJsonDefPaths failed - %s", err)
+		t.Fatalf("GetAllConfigJsonPaths failed - %s", err)
 	}
 
 	pack1Paths, ok1 := jsonPaths[Pack1Name]
@@ -84,9 +84,9 @@ func TestGetPackageJsonDefPaths(t *testing.T) {
 		ContextPath: Set1DirPath,
 	}
 
-	pack1Paths, err := context.GetPackageJsonDefPaths(Pack1Name)
+	pack1Paths, err := context.GetConfigJsonPaths(Pack1Name, bringauto_const.PackageDirName)
 	if err != nil {
-		t.Fatalf("GetPackageJsonDefPaths failed - %s", err)
+		t.Fatalf("GetConfigJsonPaths failed - %s", err)
 	}
 
 	commonPath := filepath.Join(Set1DirPath, bringauto_const.PackageDirName)
@@ -104,9 +104,9 @@ func TestGetAllPackagesConfigs(t *testing.T) {
 		ContextPath: Set1DirPath,
 	}
 
-	configs, err := context.GetAllPackagesConfigs(&defaultPlatformString)
+	configs, err := context.GetAllConfigs(&defaultPlatformString, bringauto_const.PackageDirName)
 	if err != nil {
-		t.Fatalf("GetAllPackagesConfigs failed - %s", err)
+		t.Fatalf("GetAllConfigs failed - %s", err)
 	}
 
 	if len(configs) != 4 {

--- a/modules/bringauto_context/test_data/set1/app/app1/app1_debug.json
+++ b/modules/bringauto_context/test_data/set1/app/app1/app1_debug.json
@@ -1,0 +1,27 @@
+{
+  "Env": {},
+  "Git": {
+    "URI": "https://github.com/bringauto/app1.git",
+    "Revision": "v1.0.0"
+  },
+  "Build": {
+    "CMake": {
+      "Defines": {}
+    }
+  },
+  "Package": {
+    "Name": "pack1",
+    "VersionTag": "v1.0.0",
+    "PlatformString": {
+      "Mode": "auto"
+    },
+    "IsLibrary": false,
+    "IsDevLib": false,
+    "IsDebug": true
+  },
+  "DockerMatrix": {
+    "ImageNames": [
+      "image1"
+    ]
+  }
+}

--- a/modules/bringauto_context/test_data/set1/app/app1/app1_release.json
+++ b/modules/bringauto_context/test_data/set1/app/app1/app1_release.json
@@ -1,0 +1,27 @@
+{
+  "Env": {},
+  "Git": {
+    "URI": "https://github.com/bringauto/app1.git",
+    "Revision": "v1.0.0"
+  },
+  "Build": {
+    "CMake": {
+      "Defines": {}
+    }
+  },
+  "Package": {
+    "Name": "pack1",
+    "VersionTag": "v1.0.0",
+    "PlatformString": {
+      "Mode": "auto"
+    },
+    "IsLibrary": false,
+    "IsDevLib": false,
+    "IsDebug": false
+  },
+  "DockerMatrix": {
+    "ImageNames": [
+      "image1"
+    ]
+  }
+}

--- a/modules/bringauto_context/test_data/set2/app/app1/app1_debug.json
+++ b/modules/bringauto_context/test_data/set2/app/app1/app1_debug.json
@@ -1,0 +1,27 @@
+{
+  "Env": {},
+  "Git": {
+    "URI": "https://github.com/bringauto/app1.git",
+    "Revision": "v1.0.0"
+  },
+  "Build": {
+    "CMake": {
+      "Defines": {}
+    }
+  },
+  "Package": {
+    "Name": "pack1",
+    "VersionTag": "v1.0.0",
+    "PlatformString": {
+      "Mode": "auto"
+    },
+    "IsLibrary": false,
+    "IsDevLib": false,
+    "IsDebug": true
+  },
+  "DockerMatrix": {
+    "ImageNames": [
+      "image1"
+    ]
+  }
+}

--- a/modules/bringauto_context/test_data/set2/app/app1/app1_release.json
+++ b/modules/bringauto_context/test_data/set2/app/app1/app1_release.json
@@ -1,0 +1,27 @@
+{
+  "Env": {},
+  "Git": {
+    "URI": "https://github.com/bringauto/app1.git",
+    "Revision": "v1.0.0"
+  },
+  "Build": {
+    "CMake": {
+      "Defines": {}
+    }
+  },
+  "Package": {
+    "Name": "pack1",
+    "VersionTag": "v1.0.0",
+    "PlatformString": {
+      "Mode": "auto"
+    },
+    "IsLibrary": false,
+    "IsDevLib": false,
+    "IsDebug": false
+  },
+  "DockerMatrix": {
+    "ImageNames": [
+      "image1"
+    ]
+  }
+}

--- a/modules/bringauto_context/test_data/set3/app/app1/app1_debug.json
+++ b/modules/bringauto_context/test_data/set3/app/app1/app1_debug.json
@@ -1,0 +1,27 @@
+{
+  "Env": {},
+  "Git": {
+    "URI": "https://github.com/bringauto/app1.git",
+    "Revision": "v1.0.0"
+  },
+  "Build": {
+    "CMake": {
+      "Defines": {}
+    }
+  },
+  "Package": {
+    "Name": "pack1",
+    "VersionTag": "v1.0.0",
+    "PlatformString": {
+      "Mode": "auto"
+    },
+    "IsLibrary": false,
+    "IsDevLib": false,
+    "IsDebug": true
+  },
+  "DockerMatrix": {
+    "ImageNames": [
+      "image1"
+    ]
+  }
+}

--- a/modules/bringauto_context/test_data/set3/app/app1/app1_release.json
+++ b/modules/bringauto_context/test_data/set3/app/app1/app1_release.json
@@ -1,0 +1,27 @@
+{
+  "Env": {},
+  "Git": {
+    "URI": "https://github.com/bringauto/app1.git",
+    "Revision": "v1.0.0"
+  },
+  "Build": {
+    "CMake": {
+      "Defines": {}
+    }
+  },
+  "Package": {
+    "Name": "pack1",
+    "VersionTag": "v1.0.0",
+    "PlatformString": {
+      "Mode": "auto"
+    },
+    "IsLibrary": false,
+    "IsDevLib": false,
+    "IsDebug": false
+  },
+  "DockerMatrix": {
+    "ImageNames": [
+      "image1"
+    ]
+  }
+}

--- a/modules/bringauto_context/test_data/set4/app/app1/app1_debug.json
+++ b/modules/bringauto_context/test_data/set4/app/app1/app1_debug.json
@@ -1,0 +1,27 @@
+{
+  "Env": {},
+  "Git": {
+    "URI": "https://github.com/bringauto/app1.git",
+    "Revision": "v1.0.0"
+  },
+  "Build": {
+    "CMake": {
+      "Defines": {}
+    }
+  },
+  "Package": {
+    "Name": "pack1",
+    "VersionTag": "v1.0.0",
+    "PlatformString": {
+      "Mode": "auto"
+    },
+    "IsLibrary": false,
+    "IsDevLib": false,
+    "IsDebug": true
+  },
+  "DockerMatrix": {
+    "ImageNames": [
+      "image1"
+    ]
+  }
+}

--- a/modules/bringauto_context/test_data/set4/app/app1/app1_release.json
+++ b/modules/bringauto_context/test_data/set4/app/app1/app1_release.json
@@ -1,0 +1,27 @@
+{
+  "Env": {},
+  "Git": {
+    "URI": "https://github.com/bringauto/app1.git",
+    "Revision": "v1.0.0"
+  },
+  "Build": {
+    "CMake": {
+      "Defines": {}
+    }
+  },
+  "Package": {
+    "Name": "pack1",
+    "VersionTag": "v1.0.0",
+    "PlatformString": {
+      "Mode": "auto"
+    },
+    "IsLibrary": false,
+    "IsDevLib": false,
+    "IsDebug": false
+  },
+  "DockerMatrix": {
+    "ImageNames": [
+      "image1"
+    ]
+  }
+}

--- a/modules/bringauto_repository/default_test.go
+++ b/modules/bringauto_repository/default_test.go
@@ -84,6 +84,7 @@ func TestCreatePackagePath(t *testing.T) {
 	packPath := repo.CreatePath(pack1, bringauto_const.PackageDirName)
 	expectedPackPath := filepath.Join(
 		RepoName,
+		bringauto_const.PackageDirName,
 		pack1.PlatformString.String.DistroName,
 		pack1.PlatformString.String.DistroRelease,
 		pack1.PlatformString.String.Machine,

--- a/modules/bringauto_repository/default_test.go
+++ b/modules/bringauto_repository/default_test.go
@@ -4,6 +4,7 @@ import (
 	"bringauto/modules/bringauto_testing"
 	"bringauto/modules/bringauto_package"
 	"bringauto/modules/bringauto_prerequisites"
+	"bringauto/modules/bringauto_const"
 	"fmt"
 	"os"
 	"os/exec"
@@ -80,7 +81,7 @@ func TestCreatePackagePath(t *testing.T) {
 		t.Fatalf("can't initialize Git repository or struct - %s", err)
 	}
 
-	packPath := repo.CreatePackagePath(pack1)
+	packPath := repo.CreatePath(pack1, bringauto_const.PackageDirName)
 	expectedPackPath := filepath.Join(
 		RepoName,
 		pack1.PlatformString.String.DistroName,
@@ -105,12 +106,12 @@ func TestCopyToRepositoryOnePackage(t *testing.T) {
 		t.Fatalf("can't initialize Git repository or struct - %s", err)
 	}
 
-	err = repo.CopyToRepository(pack1, bringauto_testing.Pack1Name)
+	err = repo.CopyToRepository(pack1, bringauto_testing.Pack1Name, bringauto_const.PackageDirName)
 	if err != nil {
 		t.Errorf("CopyToRepository failed - %s", err)
 	}
 
-	packFilePath := filepath.Join(repo.CreatePackagePath(pack1), pack1.GetFullPackageName() + ZipExtension)
+	packFilePath := filepath.Join(repo.CreatePath(pack1, bringauto_const.PackageDirName), pack1.GetFullPackageName() + ZipExtension)
 	_, err = os.ReadFile(packFilePath)
 	if os.IsNotExist(err) {
 		t.Fail()
@@ -128,34 +129,34 @@ func TestCopyToRepositoryMultiplePackages(t *testing.T) {
 		t.Fatalf("can't initialize Git repository or struct - %s", err)
 	}
 
-	err = repo.CopyToRepository(pack1, bringauto_testing.Pack2Name)
+	err = repo.CopyToRepository(pack1, bringauto_testing.Pack2Name, bringauto_const.PackageDirName)
 	if err != nil {
 		t.Errorf("CopyToRepository failed - %s", err)
 	}
 
-	err = repo.CopyToRepository(pack2, bringauto_testing.Pack2Name)
+	err = repo.CopyToRepository(pack2, bringauto_testing.Pack2Name, bringauto_const.PackageDirName)
 	if err != nil {
 		t.Errorf("CopyToRepository failed - %s", err)
 	}
 
-	err = repo.CopyToRepository(pack3, bringauto_testing.Pack3Name)
+	err = repo.CopyToRepository(pack3, bringauto_testing.Pack3Name, bringauto_const.PackageDirName)
 	if err != nil {
 		t.Errorf("CopyToRepository failed - %s", err)
 	}
 
-	pack1FilePath := filepath.Join(repo.CreatePackagePath(pack1), pack1.GetFullPackageName() + ZipExtension)
+	pack1FilePath := filepath.Join(repo.CreatePath(pack1, bringauto_const.PackageDirName), pack1.GetFullPackageName() + ZipExtension)
 	_, err = os.ReadFile(pack1FilePath)
 	if os.IsNotExist(err) {
 		t.Fail()
 	}
 
-	pack2FilePath := filepath.Join(repo.CreatePackagePath(pack2), pack2.GetFullPackageName() + ZipExtension)
+	pack2FilePath := filepath.Join(repo.CreatePath(pack2, bringauto_const.PackageDirName), pack2.GetFullPackageName() + ZipExtension)
 	_, err = os.ReadFile(pack2FilePath)
 	if os.IsNotExist(err) {
 		t.Fail()
 	}
 
-	pack3FilePath := filepath.Join(repo.CreatePackagePath(pack3), pack3.GetFullPackageName() + ZipExtension)
+	pack3FilePath := filepath.Join(repo.CreatePath(pack3, bringauto_const.PackageDirName), pack3.GetFullPackageName() + ZipExtension)
 	_, err = os.ReadFile(pack3FilePath)
 	if os.IsNotExist(err) {
 		t.Fail()
@@ -173,7 +174,7 @@ func TestCommitAllChanges(t *testing.T) {
 		t.Fatalf("can't initialize Git repository or struct - %s", err)
 	}
 
-	err = repo.CopyToRepository(pack1, bringauto_testing.Pack1Name)
+	err = repo.CopyToRepository(pack1, bringauto_testing.Pack1Name, bringauto_const.PackageDirName)
 	if err != nil {
 		t.Errorf("CopyToRepository failed - %s", err)
 	}
@@ -219,7 +220,7 @@ func TestRestoreAllChanges(t *testing.T) {
 		t.Fatalf("can't initialize Git repository or struct - %s", err)
 	}
 
-	err = repo.CopyToRepository(pack1, bringauto_testing.Pack1Name)
+	err = repo.CopyToRepository(pack1, bringauto_testing.Pack1Name, bringauto_const.PackageDirName)
 	if err != nil {
 		t.Errorf("CopyToRepository failed - %s", err)
 	}

--- a/modules/bringauto_sysroot/Sysroot.go
+++ b/modules/bringauto_sysroot/Sysroot.go
@@ -197,3 +197,7 @@ func getExistingFilesInDir(dirPath string) []string {
 
 	return existingFiles
 }
+
+func RemoveInstallSysroot() {
+	os.RemoveAll(sysrootDirectoryName)
+}

--- a/modules/bringauto_sysroot/Sysroot.go
+++ b/modules/bringauto_sysroot/Sysroot.go
@@ -198,6 +198,6 @@ func getExistingFilesInDir(dirPath string) []string {
 	return existingFiles
 }
 
-func RemoveInstallSysroot() {
-	os.RemoveAll(sysrootDirectoryName)
+func RemoveInstallSysroot() error {
+	return os.RemoveAll(sysrootDirectoryName)
 }


### PR DESCRIPTION
We want to build apps which manages their own dependencies. During app build these dependencies are copied to sysroot independently on packager. These apps are not reliably usable with current packager workflow, because there is no way to check for overlapping files in sysroot for dependencies not controlled by packager. New workflow for reliable build of these apps should be added to packager.

- [x] Add new `build-app` command
- [x] Change semantics of Git Lfs to support Apps
- [x] Add check for `app` directory in Context
- [x] Add example Apps
- [x] Add check for empty DependsOn
- [x] Update documentation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new "build-app" command, enabling streamlined building of applications—either all at once or individually—with enhanced error handling and cleanup of build directories.
  
- **Documentation**
  - Updated guidelines and usage instructions across multiple resources to clarify the build process, now covering both packages and applications.
  
- **New Configurations**
  - Added configuration files supporting both debug and release builds for various modules, ensuring tailored build parameters for each environment.
  
- **Improvements**
  - Enhanced error handling and clarity in the context structure to accommodate both packages and applications.
  - Updated the Package Repository documentation to include references to applications alongside packages, ensuring consistency in terminology and functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->