### PR TITLE
Do not build already built Packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,14 @@ for built Packages. Given Git Repository must be created before usage.
 
 **Note:** If you do not have `bap-builder` in your system path, you need to use `./bap-builder/bap-builder` instead of `bap-builder`.
 
+## Tests
+
+To run unit tests, run:
+
+```bash
+    go test ./...
+```
+
 ## Documentation
 
 The detailed documentation is available in the `doc` directory.

--- a/bap-builder/PackageMode.go
+++ b/bap-builder/PackageMode.go
@@ -558,8 +558,8 @@ func isPackageWithDepsInSysroot(packageName string, contextManager *bringauto_co
 		builtPackage := bringauto_sysroot.BuiltPackage {
 			Name: config.Package.GetShortPackageName(),
 			DirName: sysroot.GetDirNameInSysroot(),
-			GitUrl: config.Git.URI,
-			GitCommitHash: "",
+			GitUri: config.Git.URI,
+			GitCommitHash: bringauto_const.EmptyGitCommitHash,
 		}
 		if !sysroot.IsPackageInSysroot(builtPackage) {
 			return false, nil

--- a/bap-builder/PackageMode.go
+++ b/bap-builder/PackageMode.go
@@ -463,7 +463,6 @@ func buildAndCopyPackage(
 		err = bringauto_prerequisites.Initialize(&sysroot)
 		buildConfig.SetSysroot(&sysroot)
 
-		logger.InfoIndent("Run build inside container")
 		removeHandler = bringauto_process.SignalHandlerAddHandler(buildConfig.CleanUp)
 		err, buildPerformed := buildConfig.RunBuild()
 		if err != nil {

--- a/doc/BuildProcess.md
+++ b/doc/BuildProcess.md
@@ -25,6 +25,10 @@ to the `install_sysroot` directory located in the working directory of the build
 build files would overwrite any files already present in sysroot, the build fails (more in
 [Sysroot]).
 
+Before build of a Package, the `built_packages.json` in `install_sysroot` directory is checked (if
+it exists) for Packages already built in sysroot. If the Package is present, the build is skipped.
+More informations in [Sysroot].
+
 Each Package has a `IsDebug` flag. If the flag is true the Package is considered as Debug Package.
 If the Package is false the Package is considered as Release.
 

--- a/doc/PackageRepository.md
+++ b/doc/PackageRepository.md
@@ -31,8 +31,6 @@ Following rules ans mechanisms ensures that the Package Repository is always con
 
 - Each succesfully built Package/App by `build-package`/`build-app` command is copied to Package
 Repository (specified by cli flag) to specific path -
-`<DISTRO_NAME>/<DISTRO_VERSION/MACHINE_TYPE/PACKAGE_NAME>`
-- After all Packages/Apps are succesfully built, all copied files in Package Repository are git
-committed and remain in Repository
-- If any build fails or the script is interrupted, all copied Packages/Apps are removed from
+`<DISTRO_NAME>/<DISTRO_VERSION/MACHINE_TYPE/PACKAGE_NAME>` and git committed
+- If any build fails or the script is interrupted, all not committed changes are removed from
 Repository

--- a/doc/Sysroot.md
+++ b/doc/Sysroot.md
@@ -17,9 +17,9 @@ that the Package tries to overwrite files in sysroot, which would corrupt consis
 directory. If Package doesn't try to overwrite any files, the build proceeds and Package files are
 added to the Package Repository.
 
-- Copied Package names are added to `built_packages.json` file in `install_sysroot` directory. When
-the `build-package` command with `--build-deps-on` option is used, it is expected that the Package
-with its dependencies are already in sysroot. If it is not (the Package is not in `built_packages.json` file), the error is printed and build fails.
+- Copied Package informations are added to built Packages file (more below). When the
+`build-package` command with `--build-deps-on` option is used, it is expected that the Package with
+its dependencies are already in sysroot. If it is not, the error is printed and build fails.
 
 - When `create-sysroot` command is used, all Packages in Package Repository for given target platform
 files are copied to new sysroot directory. Because of the sysroot consistency mechanism this new
@@ -29,9 +29,28 @@ sysroot will also be consistent.
 build (with Apps the sysroot does not have to be shared between builds). If single App is being
 build, the sysroot is not deleted so the user can check the sysroot after build.
 
+## Built Packages
+
+The `built_packages.json` file in `install_sysroot` directory contains already built Packages in
+sysroot. When building a Package, it is first checked if the Package is already built in sysroot.
+If it is, the build is skipped, else it continues. It is also used when building with
+`--build-deps-on` flag for check that needed Packages are already built.
+
+Built Package in `install_sysroot` is identified with these values:
+
+- Package name also with `d` suffix and `lib` prefix
+- Directory name in sysroot - this is for resolution of Package builds for specific image
+- Git URL of the Package
+- Git commit hash which is obtained after the Package is git cloned to docker container
+
+The git informations ensures that if the Package git repository is changed (commit hash or git URL
+changes) the Package will be build again. Note that the build will probably fail, because the
+Package would probably overwrite its own files in sysroot.
+
+If the user wants to force build of Package already built in sysroot, the `install_sysroot`
+directory must be deleted.
+
 ## Notes
 
-- The `install_sysroot` directory is not being deleted at the end of BAP execution (for a backup
-reason). If the user wants to build the same Packages again, it is a common practice to delete this
-directory manually. If it is not deleted and same Packages are build, the build obviously fails
-because same Package wants to overwrite its own files, which are already present in sysroot.
+- The `install_sysroot` directory is not being deleted when building Packages (for a backup
+reason), it is only deleted when building all Apps

--- a/example/docker/fleet-os-2/init_toolchain.sh
+++ b/example/docker/fleet-os-2/init_toolchain.sh
@@ -7,7 +7,7 @@ TOOLS_INSTALL_DIR="$2"
 TMP_DIR="/tmp/toolchain-install"
 
 TOOLS_PACKAGE_URI="https://github.com/bringauto/packager/releases/download/v0.3.0/bringauto-packager-tools_v0.3.0_x86-64-linux.zip"
-TOOLCHAIN_PACKAGE_URI="https://gitlab.bringauto.com/bringauto-public/fleet-os-toolchain/-/raw/master/fleet-os/v2.3.0/fleet-os-toolchain_v2.3.0_raspberrypi4-64.zip"
+TOOLCHAIN_PACKAGE_URI="https://gitlab.bringauto.com/bringauto-public/fleet-os-toolchain/-/raw/add-v2.9.0/fleet-os/v2.9.1/fleet-os-toolchain_v2.9.1_raspberrypi4-64.zip?ref_type=heads"
 
 if [[ ${INSTALL_DIR} = "" ]]
 then

--- a/modules/bringauto_build/Build.go
+++ b/modules/bringauto_build/Build.go
@@ -117,6 +117,10 @@ func (build *Build) RunBuild() (error, bool) {
 		return err, false
 	}
 
+	if build.BuiltPackage == nil {
+		return fmt.Errorf("BuiltPackage is nil"), false
+	}
+
 	build.Git.ClonePath = dockerGitCloneDirConst
 	build.CMake.SourceDir = dockerGitCloneDirConst
 

--- a/modules/bringauto_build/Build.go
+++ b/modules/bringauto_build/Build.go
@@ -1,21 +1,21 @@
 package bringauto_build
 
 import (
+	"bringauto/modules/bringauto_const"
 	"bringauto/modules/bringauto_docker"
 	"bringauto/modules/bringauto_git"
 	"bringauto/modules/bringauto_log"
-	"bringauto/modules/bringauto_const"
 	"bringauto/modules/bringauto_package"
 	"bringauto/modules/bringauto_prerequisites"
+	"bringauto/modules/bringauto_process"
 	"bringauto/modules/bringauto_ssh"
 	"bringauto/modules/bringauto_sysroot"
-	"bringauto/modules/bringauto_process"
+	"bufio"
 	"fmt"
 	"io"
-	"bufio"
-	"regexp"
 	"os"
 	"path/filepath"
+	"regexp"
 	"time"
 )
 
@@ -173,7 +173,7 @@ func (build *Build) RunBuild() (error, bool) {
 		return err, false
 	}
 
-	logger.InfoIndent("Cloning and updating Package git repository inside docker container")
+	logger.InfoIndent("Cloning Package git repository inside docker container")
 
 	err = build.prepareBuild(&shellEvaluator)
 	if err != nil {
@@ -300,7 +300,7 @@ func (build *Build) getGitCommitHash() (string, error) {
 		Commands: gitGetHash.ConstructCMDLine(),
 		StdOut:   pipeWriter,
 	}
-	
+
 	err := shellEvaluator.RunOverSSH(*build.SSHCredentials)
 	if err != nil {
 		return "", err
@@ -313,7 +313,7 @@ func (build *Build) getGitCommitHash() (string, error) {
 		line, err = buf.ReadString('\n')
 		if err == io.EOF {
 			break
-		} 
+		}
 		if err != nil {
 			return "", err
 		}

--- a/modules/bringauto_build/Build.go
+++ b/modules/bringauto_build/Build.go
@@ -190,9 +190,12 @@ func (build *Build) RunBuild() (error, bool) {
 		logger.InfoIndent("Package already built in sysroot - skipping build")
 		return nil, false
 	}
+	startupScript := bringauto_prerequisites.CreateAndInitialize[StartupScript]()
 
 	buildChain := BuildChain{
 		Chain: []CMDLineInterface{
+			startupScript,
+			build.Env,
 			build.CMake,
 			build.GNUMake,
 		},

--- a/modules/bringauto_build/Build.go
+++ b/modules/bringauto_build/Build.go
@@ -142,7 +142,7 @@ func (build *Build) prepareForBuild() error {
 // Creates a Docker container, performs a build in it. After build, the files are downloaded to
 // local directory and Docker container is stopped and removed. Returns bool which indicates if
 // the build was performed succesfully.
-func (build *Build) RunBuild() (error, bool) {
+func (build *Build) RunBuild() (error, bool) { // Long function - it is hard to refactor to make readability better
 	err := build.prepareForBuild()
 	if err != nil {
 		return err, false
@@ -338,7 +338,7 @@ func (build *Build) getGitCommitHash() (string, error) {
 }
 
 func getGitCommitHashFromLine(line string) string {
-	// regexp for long git commit hash
+	// regexp for long git commit hash, it must be used, because the ssh output has several commands and it is long
 	re := regexp.MustCompile("[a-f0-9]{40}")
 	match := re.FindStringSubmatch(line)
 	if len(match) > 0 {

--- a/modules/bringauto_build/Build.go
+++ b/modules/bringauto_build/Build.go
@@ -293,6 +293,8 @@ func (build *Build) downloadInstalledFiles() error {
 
 func (build *Build) getGitCommitHash() (string, error) {
 	pipeReader, pipeWriter := io.Pipe()
+	defer pipeReader.Close()
+	defer pipeWriter.Close()
 	gitGetHash := bringauto_git.GitGetHash{Git: *build.Git}
 	shellEvaluator := bringauto_ssh.ShellEvaluator{
 		Commands: gitGetHash.ConstructCMDLine(),

--- a/modules/bringauto_build/Build.go
+++ b/modules/bringauto_build/Build.go
@@ -11,6 +11,9 @@ import (
 	"bringauto/modules/bringauto_sysroot"
 	"bringauto/modules/bringauto_process"
 	"fmt"
+	"io"
+	"bufio"
+	"regexp"
 	"os"
 	"path/filepath"
 	"time"
@@ -24,6 +27,7 @@ type Build struct {
 	GNUMake        *GNUMake
 	SSHCredentials *bringauto_ssh.SSHCredentials
 	Package        *bringauto_package.Package
+	BuiltPackage   *bringauto_sysroot.BuiltPackage
 	sysroot        *bringauto_sysroot.Sysroot
 }
 
@@ -75,14 +79,42 @@ func (build *Build) CheckPrerequisites(*bringauto_prerequisites.Args) error {
 	return nil
 }
 
+func (build *Build) prepareBuild(shellEvaluator *bringauto_ssh.ShellEvaluator) error {
+	gitClone := bringauto_git.GitClone{Git: *build.Git}
+	gitCheckout := bringauto_git.GitCheckout{Git: *build.Git}
+	gitSubmoduleUpdate := bringauto_git.GitSubmoduleUpdate{Git: *build.Git}
+	startupScript := bringauto_prerequisites.CreateAndInitialize[StartupScript]()
+
+	preparePackageChain := BuildChain{
+		Chain: []CMDLineInterface{
+			startupScript,
+			build.Env,
+			&gitClone,
+			&gitCheckout,
+			&gitSubmoduleUpdate,
+		},
+	}
+
+	shellEvaluator.Commands = preparePackageChain.GenerateCommands()
+
+	err := shellEvaluator.RunOverSSH(*build.SSHCredentials)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
 // RunBuild
-// s
-func (build *Build) RunBuild() error {
+// Creates a Docker container, performs a build in it. After build, the files are downloaded to
+// local directory and Docker container is stopped and removed. Returns bool which indicates if
+// the build was performed succesfully.
+func (build *Build) RunBuild() (error, bool) {
 	var err error
 
 	err = build.CheckPrerequisites(nil)
 	if err != nil {
-		return err
+		return err, false
 	}
 
 	build.Git.ClonePath = dockerGitCloneDirConst
@@ -90,7 +122,7 @@ func (build *Build) RunBuild() error {
 
 	_, found := build.CMake.Defines["CMAKE_INSTALL_PREFIX"]
 	if found {
-		return fmt.Errorf("do not specify CMAKE_INSTALL_PREFIX")
+		return fmt.Errorf("do not specify CMAKE_INSTALL_PREFIX"), false
 	}
 	build.CMake.Defines["CMAKE_INSTALL_PREFIX"] = bringauto_const.DockerInstallDirConst
 
@@ -101,42 +133,25 @@ func (build *Build) RunBuild() error {
 		build.CMake.SetDefine("CMAKE_PREFIX_PATH", "/sysroot")
 	}
 
-	gitClone := bringauto_git.GitClone{Git: *build.Git}
-	gitCheckout := bringauto_git.GitCheckout{Git: *build.Git}
-	gitSubmoduleUpdate := bringauto_git.GitSubmoduleUpdate{Git: *build.Git}
-	startupScript := bringauto_prerequisites.CreateAndInitialize[StartupScript]()
-
-	buildChain := BuildChain{
-		Chain: []CMDLineInterface{
-			startupScript,
-			build.Env,
-			&gitClone,
-			&gitCheckout,
-			&gitSubmoduleUpdate,
-			build.CMake,
-			build.GNUMake,
-		},
-	}
-
 	logger := bringauto_log.GetLogger()
 	packBuildChainLogger := logger.CreateContextLogger(build.Docker.ImageName, build.Package.GetShortPackageName(), bringauto_log.BuildChainContext)
 	file, err := packBuildChainLogger.GetFile()
 
 	if err != nil {
 		logger.Error("Failed to open file - %s", err)
-		return err
+		return err, false
 	}
 
 	defer file.Close()
 
 	shellEvaluator := bringauto_ssh.ShellEvaluator{
-		Commands: buildChain.GenerateCommands(),
+		Commands: []string{},
 		StdOut:   file,
 	}
 
 	err = bringauto_prerequisites.Initialize(build.Docker)
 	if err != nil {
-		return err
+		return err, false
 	}
 
 	dockerRun := (*bringauto_docker.DockerRun)(build.Docker)
@@ -149,18 +164,47 @@ func (build *Build) RunBuild() error {
 
 	err = dockerRun.Run()
 	if err != nil {
-		return err
+		return err, false
 	}
+
+	err = build.prepareBuild(&shellEvaluator)
+	if err != nil {
+		return err, false
+	}
+
+	build.BuiltPackage.GitCommitHash, err = build.getGitCommitHash()
+	if err != nil {
+		return fmt.Errorf("can't get git commit hash from container - %s", err), false
+	}
+	build.BuiltPackage.DirName = build.sysroot.GetDirNameInSysroot()
+
+	if build.sysroot.IsPackageInSysroot(*build.BuiltPackage) {
+		logger.InfoIndent("Package already built in sysroot - skipping build")
+		return nil, false
+	}
+
+	buildChain := BuildChain{
+		Chain: []CMDLineInterface{
+			build.CMake,
+			build.GNUMake,
+		},
+	}
+
+	shellEvaluator.Commands = buildChain.GenerateCommands()
 
 	err = shellEvaluator.RunOverSSH(*build.SSHCredentials)
 	if err != nil {
-		return err
+		return err, false
 	}
 
 	logger.InfoIndent("Copying install files from container to local directory")
 
 	err = build.downloadInstalledFiles()
-	return err
+	if err != nil {
+		return fmt.Errorf("can't download files from container to local directory"), false
+	}
+
+	return nil, true
 }
 
 func (build *Build) SetSysroot(sysroot *bringauto_sysroot.Sysroot) {
@@ -235,4 +279,50 @@ func (build *Build) downloadInstalledFiles() error {
 	}
 	err = sftpClient.DownloadDirectory()
 	return err
+}
+
+func (build *Build) getGitCommitHash() (string, error) {
+	pipeReader, pipeWriter := io.Pipe()
+	gitGetHash := bringauto_git.GitGetHash{Git: *build.Git}
+	shellEvaluator := bringauto_ssh.ShellEvaluator{
+		Commands: gitGetHash.ConstructCMDLine(),
+		StdOut:   pipeWriter,
+	}
+	
+	err := shellEvaluator.RunOverSSH(*build.SSHCredentials)
+	if err != nil {
+		return "", err
+	}
+
+	buf := bufio.NewReader(pipeReader)
+	var line string
+
+	for {
+		line, err = buf.ReadString('\n')
+		if err == io.EOF {
+			break
+		} 
+		if err != nil {
+			return "", err
+		}
+
+		line = line[:len(line)-1]
+		hash := getGitCommitHashFromLine(line)
+		if hash != "" {
+			return hash, nil
+		}
+	}
+
+	return "", fmt.Errorf("no commit hash in output")
+}
+
+func getGitCommitHashFromLine(line string) string {
+	// regexp for long git commit hash
+	re := regexp.MustCompile("[a-f0-9]{40}")
+	match := re.FindStringSubmatch(line)
+	if len(match) > 0 {
+		return match[0]
+	}
+
+	return ""
 }

--- a/modules/bringauto_build/Build.go
+++ b/modules/bringauto_build/Build.go
@@ -162,10 +162,14 @@ func (build *Build) RunBuild() (error, bool) {
 	})
 	defer removeHandler()
 
+	logger.InfoIndent("Starting docker container")
+
 	err = dockerRun.Run()
 	if err != nil {
 		return err, false
 	}
+
+	logger.InfoIndent("Cloning and updating Package git repository inside docker container")
 
 	err = build.prepareBuild(&shellEvaluator)
 	if err != nil {
@@ -191,6 +195,8 @@ func (build *Build) RunBuild() (error, bool) {
 	}
 
 	shellEvaluator.Commands = buildChain.GenerateCommands()
+
+	logger.InfoIndent("Running build inside container")
 
 	err = shellEvaluator.RunOverSSH(*build.SSHCredentials)
 	if err != nil {

--- a/modules/bringauto_config/Config.go
+++ b/modules/bringauto_config/Config.go
@@ -6,6 +6,7 @@ import (
 	"bringauto/modules/bringauto_git"
 	"bringauto/modules/bringauto_package"
 	"bringauto/modules/bringauto_prerequisites"
+	"bringauto/modules/bringauto_sysroot"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -16,7 +17,6 @@ import (
 // Build
 // It stores configuration for given build system
 // (CMake, autoconf, ...)
-//
 type Build struct {
 	CMake *bringauto_build.CMake
 }
@@ -27,7 +27,6 @@ type DockerMatrix struct {
 
 // Config
 // Build configuration which stores how the package is build.
-//
 type Config struct {
 	Env          map[string]string
 	Git          bringauto_git.Git
@@ -121,6 +120,12 @@ func (config *Config) fillBuildStructure(dockerImageName string, platformString 
 	if err != nil {
 		panic(err)
 	}
+	builtPackage := bringauto_prerequisites.CreateAndInitialize[bringauto_sysroot.BuiltPackage](
+		config.Package.GetShortPackageName(),
+		"",
+		config.Git.URI,
+		"",
+	)
 
 	tmpPackage := config.Package
 	err = bringauto_prerequisites.Initialize(&tmpPackage)
@@ -132,11 +137,12 @@ func (config *Config) fillBuildStructure(dockerImageName string, platformString 
 	}
 
 	build := bringauto_build.Build{
-		Env:     env,
-		Git:     &config.Git,
-		CMake:   config.Build.CMake,
-		Package: &tmpPackage,
-		Docker:  defaultDocker,
+		Env:          env,
+		Git:          &config.Git,
+		CMake:        config.Build.CMake,
+		Package:      &tmpPackage,
+		BuiltPackage: builtPackage,
+		Docker:       defaultDocker,
 	}
 
 	return build

--- a/modules/bringauto_config/Config.go
+++ b/modules/bringauto_config/Config.go
@@ -2,6 +2,7 @@ package bringauto_config
 
 import (
 	"bringauto/modules/bringauto_build"
+	"bringauto/modules/bringauto_const"
 	"bringauto/modules/bringauto_docker"
 	"bringauto/modules/bringauto_git"
 	"bringauto/modules/bringauto_package"
@@ -122,9 +123,9 @@ func (config *Config) fillBuildStructure(dockerImageName string, platformString 
 	}
 	builtPackage := bringauto_prerequisites.CreateAndInitialize[bringauto_sysroot.BuiltPackage](
 		config.Package.GetShortPackageName(),
-		"",
+		"",                                 // Will be filled later after build will have valid sysroot
 		config.Git.URI,
-		"",
+		bringauto_const.EmptyGitCommitHash, // Will be filled later when the hash is retrieved from docker container
 	)
 
 	tmpPackage := config.Package

--- a/modules/bringauto_const/Const.go
+++ b/modules/bringauto_const/Const.go
@@ -16,4 +16,6 @@ const (
 	PackageDirName = "package"
 	// Name of the app directory
 	AppDirName = "app"
+	// Empty Git commit hash
+	EmptyGitCommitHash = ""
 )

--- a/modules/bringauto_git/Git.go
+++ b/modules/bringauto_git/Git.go
@@ -19,6 +19,10 @@ type GitCheckout struct {
 	Git
 }
 
+type GitGetHash struct {
+	Git
+}
+
 type GitSubmoduleUpdate struct {
 	Git
 }
@@ -45,6 +49,21 @@ func (args *GitCheckout) ConstructCMDLine() []string {
 		GitExecutablePath,
 		"checkout",
 		args.Revision,
+	}
+	return []string{
+		"pushd " + args.ClonePath,
+		strings.Join(cmd, " "),
+		"popd",
+	}
+}
+
+func (args *GitGetHash) ConstructCMDLine() []string {
+	validateGITPath(args.ClonePath)
+	cmd := []string{
+		GitExecutablePath,
+		"log",
+		"--pretty=format:'%H'",
+		"-1",
 	}
 	return []string{
 		"pushd " + args.ClonePath,

--- a/modules/bringauto_repository/GitLFSRepository.go
+++ b/modules/bringauto_repository/GitLFSRepository.go
@@ -51,14 +51,14 @@ func (lfs *GitLFSRepository) CheckPrerequisites(*bringauto_prerequisites.Args) e
 	return nil
 }
 
-// CommitAllChanges
-// Adds all changes to staged and then makes a commit.
-func (lfs *GitLFSRepository) CommitAllChanges() error {
+// commitPackage
+// Adds all changes to staged and then makes a commit with packageName description.
+func (lfs *GitLFSRepository) commitPackage(packageName string) error {
 	err := lfs.gitAddAll()
 	if err != nil {
 		return err
 	}
-	err = lfs.gitCommit()
+	err = lfs.gitCommit(packageName)
 	if err != nil {
 		return err
 	}
@@ -280,6 +280,11 @@ func (lfs *GitLFSRepository) CopyToRepository(pack bringauto_package.Package, so
 		return err
 	}
 
+	err = lfs.commitPackage(pack.GetFullPackageName())
+	if err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -315,12 +320,12 @@ func (lfs *GitLFSRepository) gitAddAll() error {
 }
 
 // gitCommit
-// Commits all in Git Lfs.
-func (lfs *GitLFSRepository) gitCommit() error {
+// Commits Git Lfs with packageName description.
+func (lfs *GitLFSRepository) gitCommit(packageName string) error {
 	var ok, _ = lfs.prepareAndRun([]string{
 		"commit",
 		"-m",
-		"Build packages",
+		"Build package " + packageName,
 	},
 	)
 	if !ok {

--- a/modules/bringauto_repository/default_test.go
+++ b/modules/bringauto_repository/default_test.go
@@ -169,7 +169,7 @@ func TestCopyToRepositoryMultiplePackages(t *testing.T) {
 	}
 }
 
-func TestCommitAllChanges(t *testing.T) {
+func TestCopyToRepositoryChangesCommitted(t *testing.T) {
 	repo, err := initGitRepo()
 	if err != nil {
 		t.Fatalf("can't initialize Git repository or struct - %s", err)
@@ -178,10 +178,6 @@ func TestCommitAllChanges(t *testing.T) {
 	err = repo.CopyToRepository(pack1, bringauto_testing.Pack1Name, bringauto_const.PackageDirName)
 	if err != nil {
 		t.Errorf("CopyToRepository failed - %s", err)
-	}
-	err = repo.CommitAllChanges()
-	if err != nil {
-		t.Errorf("can't commit changes - %s", err)
 	}
 
 	err = os.Chdir(RepoName)
@@ -221,10 +217,18 @@ func TestRestoreAllChanges(t *testing.T) {
 		t.Fatalf("can't initialize Git repository or struct - %s", err)
 	}
 
-	err = repo.CopyToRepository(pack1, bringauto_testing.Pack1Name, bringauto_const.PackageDirName)
+	testFile1, err := os.Create(filepath.Join(RepoName, "file1"))
 	if err != nil {
-		t.Errorf("CopyToRepository failed - %s", err)
+		t.Fatal("can't open destination package file")
 	}
+	defer testFile1.Close()
+
+	testFile2, err := os.Create(filepath.Join(RepoName, "file2"))
+	if err != nil {
+		t.Fatal("can't open destination package file")
+	}
+	defer testFile2.Close()
+
 	err = repo.RestoreAllChanges()
 	if err != nil {
 		t.Errorf("can't restore changes - %s", err)

--- a/modules/bringauto_repository/default_test.go
+++ b/modules/bringauto_repository/default_test.go
@@ -191,7 +191,7 @@ func TestCopyToRepositoryChangesCommitted(t *testing.T) {
 		t.Errorf("git status failed - %s", err)
 	}
 	if len(stdout) > 0 {
-		t.Error("git status not empty after CommitAllChanges")
+		t.Error("git status not empty")
 	}
 
 	cmd = exec.Command("git", "log")

--- a/modules/bringauto_sysroot/BuiltPackage.go
+++ b/modules/bringauto_sysroot/BuiltPackage.go
@@ -1,0 +1,44 @@
+package bringauto_sysroot
+
+import (
+	"bringauto/modules/bringauto_prerequisites"
+)
+
+// Represents one built Package in sysroot.
+type BuiltPackage struct {
+	Name string
+	DirName string
+	GitUrl string
+	GitCommitHash string
+}
+
+type builtPackageInitArgs struct {
+	Name string
+	DirName string
+	GitUrl string
+	GitCommitHash string
+}
+
+func (builtPackage *BuiltPackage) FillDefault(*bringauto_prerequisites.Args) error {
+	builtPackage.Name = ""
+	builtPackage.DirName = ""
+	builtPackage.GitUrl = ""
+	builtPackage.GitCommitHash = ""
+	return nil
+}
+
+func (builtPackage *BuiltPackage) FillDynamic(args *bringauto_prerequisites.Args) error {
+	if !bringauto_prerequisites.IsEmpty(args) {
+		var argsStruct builtPackageInitArgs
+		bringauto_prerequisites.GetArgs(args, &argsStruct)
+		builtPackage.Name = argsStruct.Name
+		builtPackage.DirName = argsStruct.DirName
+		builtPackage.GitUrl = argsStruct.GitUrl
+		builtPackage.GitCommitHash = argsStruct.GitCommitHash
+	}
+	return nil
+}
+
+func (builtPackage *BuiltPackage) CheckPrerequisites(*bringauto_prerequisites.Args) error {
+	return nil
+}

--- a/modules/bringauto_sysroot/BuiltPackage.go
+++ b/modules/bringauto_sysroot/BuiltPackage.go
@@ -4,25 +4,23 @@ import (
 	"bringauto/modules/bringauto_prerequisites"
 )
 
-// Represents one built Package in sysroot.
+// Represents one built Package in sysroot. Before build of a Package, this struct is created and
+// compared to already built Packages in sysroot (a json file in sysroot directory), if any field
+// is changed, the build is performed, else it is skipped. At the end the struct in form of a json
+// is saved to sysroot directory.
 type BuiltPackage struct {
 	Name string
 	DirName string
-	GitUrl string
+	GitUri string
 	GitCommitHash string
 }
 
-type builtPackageInitArgs struct {
-	Name string
-	DirName string
-	GitUrl string
-	GitCommitHash string
-}
+type builtPackageInitArgs BuiltPackage
 
 func (builtPackage *BuiltPackage) FillDefault(*bringauto_prerequisites.Args) error {
 	builtPackage.Name = ""
 	builtPackage.DirName = ""
-	builtPackage.GitUrl = ""
+	builtPackage.GitUri = ""
 	builtPackage.GitCommitHash = ""
 	return nil
 }
@@ -33,7 +31,7 @@ func (builtPackage *BuiltPackage) FillDynamic(args *bringauto_prerequisites.Args
 		bringauto_prerequisites.GetArgs(args, &argsStruct)
 		builtPackage.Name = argsStruct.Name
 		builtPackage.DirName = argsStruct.DirName
-		builtPackage.GitUrl = argsStruct.GitUrl
+		builtPackage.GitUri = argsStruct.GitUri
 		builtPackage.GitCommitHash = argsStruct.GitCommitHash
 	}
 	return nil

--- a/modules/bringauto_sysroot/BuiltPackages.go
+++ b/modules/bringauto_sysroot/BuiltPackages.go
@@ -9,19 +9,20 @@ import (
 
 const (
 	jsonFileName = "built_packages.json"
+	indent = "\x20\x20\x20\x20" // four spaces
 )
 
 // Contains built Packages in sysroot and has functions for Json encoding and decoding of built
 // Packages.
 type BuiltPackages struct {
-	Packages []string
+	Packages []BuiltPackage
 }
 
 // AddToBuiltPackages
 // Adds packageName to built Packages.
-func (builtPackages *BuiltPackages) AddToBuiltPackages(packageName string) error {
-	builtPackages.Packages = append(builtPackages.Packages, packageName)
-	bytes, err := json.Marshal(builtPackages.Packages)
+func (builtPackages *BuiltPackages) AddToBuiltPackages(pack BuiltPackage) error {
+	builtPackages.Packages = append(builtPackages.Packages, pack)
+	bytes, err := json.MarshalIndent(builtPackages.Packages, "", indent)
 	if err != nil {
 		return err
 	}
@@ -44,4 +45,20 @@ func (builtPackages *BuiltPackages) UpdateBuiltPackages() error {
 		return fmt.Errorf("failed to parse built packages file - %s", err)
 	}
 	return nil
+}
+
+// Contains
+// Returns true if given Package is in builtPackages, else false. If the pack has empty
+// GitCommitHash, it is not checked.
+func (builtPackages *BuiltPackages) Contains(pack BuiltPackage) bool {
+	for _, p := range builtPackages.Packages {
+		condition := p.Name == pack.Name && p.DirName == pack.DirName && pack.GitUrl == p.GitUrl
+		if pack.GitCommitHash != "" {
+			condition = condition && pack.GitCommitHash == p.GitCommitHash
+		}
+		if condition {
+			return true
+		}
+	}
+	return false
 }

--- a/modules/bringauto_sysroot/BuiltPackages.go
+++ b/modules/bringauto_sysroot/BuiltPackages.go
@@ -1,6 +1,7 @@
 package bringauto_sysroot
 
 import (
+	"bringauto/modules/bringauto_const"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -52,8 +53,8 @@ func (builtPackages *BuiltPackages) UpdateBuiltPackages() error {
 // are compared. Only if the pack has empty GitCommitHash, the GitCommitHash is not compared.
 func (builtPackages *BuiltPackages) Contains(pack BuiltPackage) bool {
 	for _, p := range builtPackages.Packages {
-		condition := p.Name == pack.Name && p.DirName == pack.DirName && pack.GitUrl == p.GitUrl
-		if pack.GitCommitHash != "" {
+		condition := p.Name == pack.Name && p.DirName == pack.DirName && pack.GitUri == p.GitUri
+		if pack.GitCommitHash != bringauto_const.EmptyGitCommitHash {
 			condition = condition && pack.GitCommitHash == p.GitCommitHash
 		}
 		if condition {

--- a/modules/bringauto_sysroot/BuiltPackages.go
+++ b/modules/bringauto_sysroot/BuiltPackages.go
@@ -48,8 +48,8 @@ func (builtPackages *BuiltPackages) UpdateBuiltPackages() error {
 }
 
 // Contains
-// Returns true if given Package is in builtPackages, else false. If the pack has empty
-// GitCommitHash, it is not checked.
+// Returns true if given Package is in builtPackages, else false. All fields of BuiltPackage struct
+// are compared. Only if the pack has empty GitCommitHash, the GitCommitHash is not compared.
 func (builtPackages *BuiltPackages) Contains(pack BuiltPackage) bool {
 	for _, p := range builtPackages.Packages {
 		condition := p.Name == pack.Name && p.DirName == pack.DirName && pack.GitUrl == p.GitUrl

--- a/modules/bringauto_sysroot/default_test.go
+++ b/modules/bringauto_sysroot/default_test.go
@@ -12,10 +12,16 @@ import (
 
 const (
 	sysrootDir = "test_sysroot"
+	gitUrl = "git.url"
+	gitCommitHash = "hash"
 )
 
 var defaultPlatformString bringauto_package.PlatformString
 var defaultSysroot Sysroot
+
+var builtPackage1 BuiltPackage
+var builtPackage2 BuiltPackage
+var builtPackage3 BuiltPackage
 
 func TestMain(m *testing.M) {
 	stringExplicit := bringauto_package.PlatformStringExplicit {
@@ -34,6 +40,21 @@ func TestMain(m *testing.M) {
 		PlatformString: &defaultPlatformString,
 	}
 	err := bringauto_prerequisites.Initialize(&defaultSysroot)
+	if err != nil {
+		panic(err)
+	}
+
+	err = bringauto_prerequisites.Initialize(&builtPackage1, bringauto_testing.Pack1Name, gitUrl, "")
+	if err != nil {
+		panic(err)
+	}
+
+	err = bringauto_prerequisites.Initialize(&builtPackage2, bringauto_testing.Pack2Name, gitUrl, "")
+	if err != nil {
+		panic(err)
+	}
+
+	err = bringauto_prerequisites.Initialize(&builtPackage3, bringauto_testing.Pack3Name, gitUrl, "")
 	if err != nil {
 		panic(err)
 	}
@@ -100,12 +121,12 @@ func TestCreateSysrootDir(t *testing.T) {
 }
 
 func TestCopyToSysrootOnePackage(t *testing.T) {
-	err := defaultSysroot.CopyToSysroot(bringauto_testing.Pack1Name, bringauto_testing.Pack1Name)
+	err := defaultSysroot.CopyToSysroot(bringauto_testing.Pack1Name, builtPackage1)
 	if err != nil {
 		t.Errorf("CopyToSysroot failed - %s", err)
 	}
 
-	pack1Path := filepath.Join(defaultSysroot.GetSysrootPath(), bringauto_testing.Pack1FileName)
+	pack1Path := filepath.Join(defaultSysroot.GetSysrootPath(), bringauto_testing.Pack1FileName, gitUrl, "")
 	_, err = os.ReadFile(pack1Path)
 	if os.IsNotExist(err) {
 		t.Fail()
@@ -118,17 +139,17 @@ func TestCopyToSysrootOnePackage(t *testing.T) {
 }
 
 func TestCopyToSysrootMultiplePackages(t *testing.T) {
-	err := defaultSysroot.CopyToSysroot(bringauto_testing.Pack1Name, bringauto_testing.Pack1Name)
+	err := defaultSysroot.CopyToSysroot(bringauto_testing.Pack1Name, builtPackage1)
 	if err != nil {
 		t.Errorf("CopyToSysroot failed - %s", err)
 	}
 
-	err = defaultSysroot.CopyToSysroot(bringauto_testing.Pack2Name, bringauto_testing.Pack2Name)
+	err = defaultSysroot.CopyToSysroot(bringauto_testing.Pack2Name, builtPackage2)
 	if err != nil {
 		t.Errorf("CopyToSysroot failed - %s", err)
 	}
 
-	err = defaultSysroot.CopyToSysroot(bringauto_testing.Pack3Name, bringauto_testing.Pack3Name)
+	err = defaultSysroot.CopyToSysroot(bringauto_testing.Pack3Name, builtPackage3)
 	if err != nil {
 		t.Errorf("CopyToSysroot failed - %s", err)
 	}
@@ -158,12 +179,12 @@ func TestCopyToSysrootMultiplePackages(t *testing.T) {
 }
 
 func TestCopyToSysrootOvewriteFiles(t *testing.T) {
-	err := defaultSysroot.CopyToSysroot(bringauto_testing.Pack1Name, bringauto_testing.Pack1Name)
+	err := defaultSysroot.CopyToSysroot(bringauto_testing.Pack1Name, builtPackage1)
 	if err != nil {
 		t.Errorf("CopyToSysroot failed - %s", err)
 	}
 
-	err = defaultSysroot.CopyToSysroot(bringauto_testing.Pack1Name, bringauto_testing.Pack1Name)
+	err = defaultSysroot.CopyToSysroot(bringauto_testing.Pack1Name, builtPackage1)
 	if err == nil {
 		t.Error("ovewriting files not detected")
 	}
@@ -184,20 +205,20 @@ func TestIsPackageInSysroot(t *testing.T) {
 		t.Fatalf("sysroot initialization failed - %s", err)
 	}
 
-	err = sysroot.CopyToSysroot(bringauto_testing.Pack1Name, bringauto_testing.Pack1Name)
+	err = sysroot.CopyToSysroot(bringauto_testing.Pack1Name, builtPackage1)
 	if err != nil {
 		t.Errorf("CopyToSysroot failed - %s", err)
 	}
 
-	if !sysroot.IsPackageInSysroot(bringauto_testing.Pack1Name) {
+	if !sysroot.IsPackageInSysroot(builtPackage1) {
 		t.Error("IsPackageInSysroot returned false after copying package to sysroot")
 	}
 
-	if sysroot.IsPackageInSysroot(bringauto_testing.Pack2Name) {
+	if sysroot.IsPackageInSysroot(builtPackage2) {
 		t.Error("IsPackageInSysroot returned true for not copied package")
 	}
 
-	if sysroot.IsPackageInSysroot(bringauto_testing.Pack3Name) {
+	if sysroot.IsPackageInSysroot(builtPackage3) {
 		t.Error("IsPackageInSysroot returned true for not copied package")
 	}
 

--- a/modules/bringauto_sysroot/default_test.go
+++ b/modules/bringauto_sysroot/default_test.go
@@ -14,6 +14,7 @@ const (
 	sysrootDir = "test_sysroot"
 	gitUrl = "git.url"
 	gitCommitHash = "hash"
+	sysrootDirName = "machine-distro-1.0"
 )
 
 var defaultPlatformString bringauto_package.PlatformString
@@ -44,17 +45,17 @@ func TestMain(m *testing.M) {
 		panic(err)
 	}
 
-	err = bringauto_prerequisites.Initialize(&builtPackage1, bringauto_testing.Pack1Name, gitUrl, "")
+	err = bringauto_prerequisites.Initialize(&builtPackage1, bringauto_testing.Pack1Name, sysrootDirName, gitUrl, "")
 	if err != nil {
 		panic(err)
 	}
 
-	err = bringauto_prerequisites.Initialize(&builtPackage2, bringauto_testing.Pack2Name, gitUrl, "")
+	err = bringauto_prerequisites.Initialize(&builtPackage2, bringauto_testing.Pack2Name, sysrootDirName, gitUrl, "")
 	if err != nil {
 		panic(err)
 	}
 
-	err = bringauto_prerequisites.Initialize(&builtPackage3, bringauto_testing.Pack3Name, gitUrl, "")
+	err = bringauto_prerequisites.Initialize(&builtPackage3, bringauto_testing.Pack3Name, sysrootDirName, gitUrl, "")
 	if err != nil {
 		panic(err)
 	}
@@ -116,6 +117,14 @@ func TestCreateSysrootDir(t *testing.T) {
 
 	_, err = os.Stat(sysrootPath)
 	if os.IsNotExist(err) {
+		t.Fail()
+	}
+}
+
+func TestGetDirNameInSysroot(t *testing.T) {
+	dirName := defaultSysroot.GetDirNameInSysroot()
+
+	if dirName != sysrootDirName {
 		t.Fail()
 	}
 }

--- a/modules/bringauto_sysroot/default_test.go
+++ b/modules/bringauto_sysroot/default_test.go
@@ -238,6 +238,35 @@ func TestIsPackageInSysroot(t *testing.T) {
 	}
 }
 
+func TestIsPackageInSysrootDifferentHash(t *testing.T) {
+	sysroot := Sysroot {
+		IsDebug: false,
+		PlatformString: &defaultPlatformString,
+	}
+	err := bringauto_prerequisites.Initialize(&defaultSysroot)
+	if err != nil {
+		t.Fatalf("sysroot initialization failed - %s", err)
+	}
+
+	err = sysroot.CopyToSysroot(bringauto_testing.Pack1Name, builtPackage1)
+	if err != nil {
+		t.Errorf("CopyToSysroot failed - %s", err)
+	}
+
+	otherPackage := builtPackage1
+	otherPackage.GitCommitHash = "different_hash"
+
+	if sysroot.IsPackageInSysroot(otherPackage) {
+		t.Error("IsPackageInSysroot returned true for different package")
+	}
+
+
+	err = clearSysroot()
+	if err != nil {
+		t.Errorf("can't delete sysroot dir - %s", err)
+	}
+}
+
 func clearSysroot() error {
 	sysrootPath := defaultSysroot.GetSysrootPath()
 	return os.RemoveAll(filepath.Dir(sysrootPath))

--- a/modules/bringauto_sysroot/default_test.go
+++ b/modules/bringauto_sysroot/default_test.go
@@ -135,7 +135,7 @@ func TestCopyToSysrootOnePackage(t *testing.T) {
 		t.Errorf("CopyToSysroot failed - %s", err)
 	}
 
-	pack1Path := filepath.Join(defaultSysroot.GetSysrootPath(), bringauto_testing.Pack1FileName, gitUrl, "")
+	pack1Path := filepath.Join(defaultSysroot.GetSysrootPath(), bringauto_testing.Pack1FileName)
 	_, err = os.ReadFile(pack1Path)
 	if os.IsNotExist(err) {
 		t.Fail()

--- a/modules/bringauto_sysroot/default_test.go
+++ b/modules/bringauto_sysroot/default_test.go
@@ -4,6 +4,7 @@ import (
 	"bringauto/modules/bringauto_testing"
 	"bringauto/modules/bringauto_package"
 	"bringauto/modules/bringauto_prerequisites"
+	"bringauto/modules/bringauto_const"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -12,7 +13,7 @@ import (
 
 const (
 	sysrootDir = "test_sysroot"
-	gitUrl = "git.url"
+	gitUri = "git_uri"
 	gitCommitHash = "hash"
 	sysrootDirName = "machine-distro-1.0"
 )
@@ -45,17 +46,17 @@ func TestMain(m *testing.M) {
 		panic(err)
 	}
 
-	err = bringauto_prerequisites.Initialize(&builtPackage1, bringauto_testing.Pack1Name, sysrootDirName, gitUrl, "")
+	err = bringauto_prerequisites.Initialize(&builtPackage1, bringauto_testing.Pack1Name, sysrootDirName, gitUri, bringauto_const.EmptyGitCommitHash)
 	if err != nil {
 		panic(err)
 	}
 
-	err = bringauto_prerequisites.Initialize(&builtPackage2, bringauto_testing.Pack2Name, sysrootDirName, gitUrl, "")
+	err = bringauto_prerequisites.Initialize(&builtPackage2, bringauto_testing.Pack2Name, sysrootDirName, gitUri, bringauto_const.EmptyGitCommitHash)
 	if err != nil {
 		panic(err)
 	}
 
-	err = bringauto_prerequisites.Initialize(&builtPackage3, bringauto_testing.Pack3Name, sysrootDirName, gitUrl, "")
+	err = bringauto_prerequisites.Initialize(&builtPackage3, bringauto_testing.Pack3Name, sysrootDirName, gitUri, bringauto_const.EmptyGitCommitHash)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
Currently the Packager builds all Packages even if they are already built in sysroot. In previous version the Built Packages json was introduced to Packager. This functionality can be extended to exclude already built Packages from builds. This will speed up builds and increases usability of Packager.

- [x] Implement not building already built Packages
- [x] Change semantics of Git Lfs --> commit after each succesfully built Package
- [x] Improve logging when building Package
- [x] Update documentation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated project documentation with a new section outlining how to run unit tests.
  - Clarified details on build processes and package management in the sysroot.
- **New Features**
  - Upgraded the toolchain to version 2.9.1 to enhance performance.
  - Introduced a new `BuiltPackage` struct to manage built package details.
  - Added a verification step to skip unnecessary rebuilds of packages in the sysroot.
- **Refactor**
  - Streamlined build workflows with improved error messaging and commit descriptions.
- **Tests**
  - Revised test configurations for more reliable validation of package handling.
  - Added new tests to verify directory name retrieval and package operations in sysroot.
  - Enhanced tests to incorporate built packages into sysroot operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->