### PR TITLE
Add not using pager in git log command

### DIFF
--- a/modules/bringauto_build/Build.go
+++ b/modules/bringauto_build/Build.go
@@ -320,14 +320,13 @@ func (build *Build) getGitCommitHash() (string, error) {
 
 	for {
 		line, err = buf.ReadString('\n')
-		if err == io.EOF {
-			break
-		}
-		if err != nil {
+		if err != nil && err != io.EOF {
 			return "", err
 		}
+		if err == nil { // The newline character is present
+			line = line[:len(line)-1]
+		}
 
-		line = line[:len(line)-1]
 		hash := getGitCommitHashFromLine(line)
 		if hash != "" {
 			return hash, nil

--- a/modules/bringauto_git/Git.go
+++ b/modules/bringauto_git/Git.go
@@ -61,6 +61,7 @@ func (args *GitGetHash) ConstructCMDLine() []string {
 	validateGITPath(args.ClonePath)
 	cmd := []string{
 		GitExecutablePath,
+		"--no-pager",
 		"log",
 		"--pretty=format:'%H'",
 		"-1",


### PR DESCRIPTION
- The `--no-pager` option was added to git log command