### PR TITLE
Add using local Package Repository option

### DIFF
--- a/bap-builder/CmdArgs.go
+++ b/bap-builder/CmdArgs.go
@@ -55,6 +55,8 @@ type BuildAppCmdLineArgs struct {
 	OutputDir *string
 	// Port for Docker container
 	Port *int
+	// Use local Package Repository inside docker container
+	UseLocalRepo *bool
 }
 
 // CreateSysrootCmdLineArgs
@@ -201,6 +203,15 @@ func (cmd *CmdLineArgs) InitFlags() {
 			Help: "Docker image name for which the Apps will be build. " +
 			"Only Apps that contains image-name in the DockerMatrix will be built. " +
 			"Given Apps will be build by toolchain represented by image-name",
+		},
+	)
+	cmd.BuildAppArgs.UseLocalRepo = cmd.buildAppParser.Flag("", "use-local-repo",
+		&argparse.Options{
+			Required: false,
+			Help: "The build of Apps will use local Package Repository instead of " +
+			"upstream. The same Package Repository from output-dir option will be " +
+			"used. All needed dependencies required by the App's CMakeLists must " +
+			"be present in this Package Repository or the build will fail.",
 		},
 	)
 	cmd.BuildAppArgs.Port = cmd.buildAppParser.Int("p", "port",

--- a/bap-builder/DockerMode.go
+++ b/bap-builder/DockerMode.go
@@ -31,7 +31,7 @@ func BuildDockerImage(cmdLine *BuildImageCmdLineArgs, contextPath string) error 
 	if err != nil {
 		return err
 	}
-	return buildSingleDockerImage(*cmdLine.Name, dockerfilePath)
+	return buildSingleDockerImage(*cmdLine.Name, dockerfilePath, contextPath)
 }
 
 // buildAllDockerImages
@@ -42,7 +42,7 @@ func buildAllDockerImages(contextManager bringauto_context.ContextManager) error
 	dockerfilePathList := contextManager.GetAllImagesDockerfilePaths()
 
 	for imageName, dockerfilePath := range dockerfilePathList {
-		err := buildSingleDockerImage(imageName, dockerfilePath)
+		err := buildSingleDockerImage(imageName, dockerfilePath, contextManager.ContextPath)
 		if err != nil {
 			return err
 		}
@@ -53,12 +53,13 @@ func buildAllDockerImages(contextManager bringauto_context.ContextManager) error
 // buildSingleDockerImage
 // builds a single docker image specified by an image name and a path to Dockerfile.
 //
-func buildSingleDockerImage(imageName string, dockerfilePath string) error {
+func buildSingleDockerImage(imageName string, dockerfilePath string, contextPath string) error {
 	logger := bringauto_log.GetLogger()
 	dockerfileDir := path.Dir(dockerfilePath)
 	dockerBuild := bringauto_docker.DockerBuild{
 		DockerfileDir: dockerfileDir,
 		Tag:           imageName,
+		Context:       contextPath,
 	}
 	logger.Info("Build Docker Image: %s", imageName)
 

--- a/bap-builder/PackageMode.go
+++ b/bap-builder/PackageMode.go
@@ -177,7 +177,13 @@ func buildAllPackages(
 
 	count := int32(0)
 	for _, config := range configList {
-		buildConfigs, err := config.GetBuildStructure(*cmdLine.DockerImageName, platformString, uint16(*cmdLine.Port))
+		buildConfigs, err := config.GetBuildStructure(
+			*cmdLine.DockerImageName,
+			platformString,
+			uint16(*cmdLine.Port),
+			false,
+			"",
+		)
 		if err != nil {
 			return err
 		}
@@ -309,7 +315,13 @@ func buildSinglePackage(
 		if !slices.Contains(config.DockerMatrix.ImageNames, *cmdLine.DockerImageName) {
 			return fmt.Errorf("'%s' does not support %s image", config.Package.Name, *cmdLine.DockerImageName)
 		}
-		buildConfigs, err := config.GetBuildStructure(*cmdLine.DockerImageName, platformString, uint16(*cmdLine.Port))
+		buildConfigs, err := config.GetBuildStructure(
+			*cmdLine.DockerImageName,
+			platformString,
+			uint16(*cmdLine.Port),
+			false,
+			"",
+		)
 		if err != nil {
 			return err
 		}

--- a/doc/ImageDefinition.md
+++ b/doc/ImageDefinition.md
@@ -1,0 +1,33 @@
+# Image definition
+
+Packager uses Dockerfiles for Image definitions. The definitions of images must be in Package
+Context in `docker` directory.
+
+## Requirements
+
+The image definitions must comply with [specified requirements](./DockerContainerRequiremetns.md).
+
+## Build context
+
+Docker build context is a set of files which can be accessed from Dockerfile. Packager sets build
+context as a directory where each Dockerfile is present in Package Context. So by default no other
+files (etc in parent directories) can not be accessed. For a use case, when user wants to add some
+common files for multiple image definitions, Packager adds additional build context which is set
+to Package Context root directory.
+
+For example to access `<package_context_root>/config/config.txt`, following Dockerfile code can be
+used:
+
+```dockerfile
+# Copy from additional build context set to Package Context root
+COPY --from=package-context config/config.txt /etc
+
+# Without specifying "--from" only files next to Dockerfile can be accessed
+COPY dir_next_to_dockerfile/config.txt /etc
+```
+
+Packager is using a Docker feature called Named contexts. Simply it adds
+`--build-context package-context=<package_context_root>` option to `docker build` command. The
+`package-context` is the name of the context (used with `--from`). The Named context is supported
+by multiple Dockerfile commands. More information can be find in
+[Docker documentation](https://docs.docker.com/build/concepts/context/).

--- a/doc/README.md
+++ b/doc/README.md
@@ -70,6 +70,7 @@ Each Package name consist from three parts:
 
 - [Context Structure]
 - [Config Structure]
+- [Image Definition]
 - [Docker Container Requirements]
 - [Build a Reliable Package Source]
 - [CMake Project Requirements]
@@ -80,6 +81,7 @@ Each Package name consist from three parts:
 [Context Structure]:               ./ContextStructure.md
 [Config Structure]:                ./ConfigStructure.md
 [Docker Container Requirements]:   ./DockerContainerRequiremetns.md
+[Image Definition]:                ./ImageDefinition.md
 [CMake Project Requirements]:      ./CMakeProjectRequirements.md
 [Build a Reliable Package Source]: ./ReliablePackageSource.md
 [Build Process]:                   ./BuildProcess.md

--- a/modules/bringauto_build/Build.go
+++ b/modules/bringauto_build/Build.go
@@ -29,6 +29,7 @@ type Build struct {
 	SSHCredentials *bringauto_ssh.SSHCredentials
 	Package        *bringauto_package.Package
 	BuiltPackage   *bringauto_sysroot.BuiltPackage
+	UseLocalRepo   bool
 	sysroot        *bringauto_sysroot.Sysroot
 }
 
@@ -88,6 +89,8 @@ func (build *Build) FillDefault(args *bringauto_prerequisites.Args) error {
 		}
 	}
 
+	build.UseLocalRepo = false
+
 	return nil
 }
 
@@ -114,6 +117,10 @@ func (build *Build) performPreBuildTasks(shellEvaluator *bringauto_ssh.ShellEval
 	startupScript, err := bringauto_prerequisites.CreateAndInitialize[StartupScript]()
 	if err != nil {
 		return err
+	}
+
+	if build.UseLocalRepo {
+		build.Env.Env["BA_PACKAGE_LOCAL_PATH"] = bringauto_const.ContainerPackageRepoPath
 	}
 
 	startupChain := BuildChain{

--- a/modules/bringauto_const/Const.go
+++ b/modules/bringauto_const/Const.go
@@ -18,4 +18,6 @@ const (
 	AppDirName = "app"
 	// Empty Git commit hash
 	EmptyGitCommitHash = ""
+	// Absolute path of Package Repository inside docker container
+	ContainerPackageRepoPath = "/lfsrepo"
 )

--- a/modules/bringauto_docker/DockerBuild.go
+++ b/modules/bringauto_docker/DockerBuild.go
@@ -13,6 +13,8 @@ type DockerBuild struct {
 	DockerfileDir string
 	// tag which will be used to tag image after build
 	Tag string
+	// build context
+	Context string
 }
 
 // Build given docker image
@@ -65,6 +67,10 @@ func prepareBuildArgs(dockerBuild *DockerBuild) []string {
 	cmdArgs = append(cmdArgs, dockerBuild.DockerfileDir)
 	if dockerBuild.DockerfileDir != "" {
 		cmdArgs = append(cmdArgs, "--tag", dockerBuild.Tag)
+	}
+
+	if dockerBuild.Context != "" {
+		cmdArgs = append(cmdArgs, "--build-context", "package-context=" + dockerBuild.Context)
 	}
 	return cmdArgs
 }


### PR DESCRIPTION
New [BacPack](https://github.com/bacpack-system) feature is in development to enable using local Package Repository during build. This PR introduces support for this feature to Packager.

New option `--use-local-repo` is introduced for `build-app` command. When it is used, app build use Package Repository given by `--output-dir` for getting dependencies.

The Apps must support this.
Requires a [new version](https://github.com/bacpack-system/package-tracker/tree/BAF-1090/local_repository) of package-tracker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added --use-local-repo flag to build Apps/Packages using a local package repository inside the container.
  - Docker builds now support a named build context (package-context) so Dockerfiles can reference files outside their directory.

- Bug Fixes
  - Improved validation and clearer messages when no Apps match or an App doesn’t support the selected image.
  - Per-app build orchestration updated to skip apps with no build configs and surface errors promptly.

- Documentation
  - Added Image Definition guide and updated README to reference it.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->