### PR TITLE
Fix using non-interactive shell

### DIFF
--- a/modules/bringauto_ssh/SSHSession.go
+++ b/modules/bringauto_ssh/SSHSession.go
@@ -103,6 +103,20 @@ func (session *SSHSession) Login(credentials SSHCredentials) error {
 		return fmt.Errorf("cannot create new SSH session")
 	}
 
+	modes := ssh.TerminalModes{
+		ssh.ECHO:          0,     // disable echoing
+		ssh.TTY_OP_ISPEED: 14400, // input speed = 14.4kbaud
+		ssh.TTY_OP_OSPEED: 14400, // output speed = 14.4kbaud
+	}
+
+	if err := sshSession.RequestPty("xterm", 80, 40, modes); err != nil {
+		err = sshSession.Close()
+		if err != nil {
+			return fmt.Errorf("tty request failed + cannot close session")
+		}
+		return fmt.Errorf("cannot request tty")
+	}
+
 	if session.StdIn != nil {
 		stdin, err := sshSession.StdinPipe()
 		if err != nil {

--- a/modules/bringauto_ssh/ShellEvaluator.go
+++ b/modules/bringauto_ssh/ShellEvaluator.go
@@ -83,7 +83,7 @@ func (shell *ShellEvaluator) RunOverSSH(credentials SSHCredentials) error {
 
 	raw := shell.getEnvStr() + shell.getPreparingCommandStr() + shell.getCommandStr()
 	safe := strings.ReplaceAll(raw, "'", "'\\''") // Escaping all single quotes
-	cmdStr := "bash -c '" + safe + "'"
+	cmdStr := "bash -li -c '" + safe + "'"
 
 	err = session.Run(cmdStr)
 	if err != nil {


### PR DESCRIPTION
Some distros require interactive shell to source bashrc file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * SSH sessions now allocate a PTY to enable fully interactive terminal behavior.
  * Remote commands are executed in a login, interactive shell so user profiles and environment are loaded.

* **Bug Fixes**
  * Improved error handling and session cleanup when terminal allocation fails, with clearer failure responses.
  * More consistent terminal input/output (echo, speeds), improving compatibility with interactive tools.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->