### PR TITLE
Update version and doc

### DIFF
--- a/doc/DockerContainerRequiremetns.md
+++ b/doc/DockerContainerRequiremetns.md
@@ -17,15 +17,11 @@ Each image that we can use for build our dependencies
 
 - Standard `bash` utility must be installed and reachable for user `root`
 
-## lsb_release and uname
+## os-release and uname
 
-`lsb_release` and `uname` are used to construct platform string.
+`/etc/os-release` file and `uname` are used to construct platform string.
 
-`lsb_release` must support
-
-- `-s` - short print that is easily parsable by machine
-- `-r` - release version (for Debian 11 it prints "11" if used with `-s` switch)
-- `-i` - distribution ID (for Debian it prints "Debian" if used with `-s` switch)
+`/etc/os-release` must include `ID` and `VERSION_ID` fields.
 
 `uname` must support
 
@@ -34,4 +30,4 @@ Each image that we can use for build our dependencies
 # Host system
 
 Docker container forward port 22 of the sshd daemon in the container to the
-port 1122 of the host system.
+specified port (1122 by default) of the host system.

--- a/doc/PlatformString.md
+++ b/doc/PlatformString.md
@@ -4,6 +4,20 @@
 Platform string is a string in form `MACHINE` - `DISTRO_NAME` - `DISTRO_VERSION`. It is used for
 Package zip filenames and paths in Package Repository and sysroot directory.
 
+## Construction
+
+The platform string is constructed from three parts:
+
+- `MACHINE` - machine architecture. For example `x86-64` or `arm64`
+- `DISTRO_NAME` - name of the distribution. For example `debian` or `fedora`
+- `DISTRO_VERSION` - version of the distribution. For example `12` or `41`
+
+For `MACHINE` the `uname -m` output is used. The output is converted to lowercase and the `_` is
+replaced with `-`. The uname is executed in the container.
+
+For `DISTRO_NAME` and `DISTRO_VERSION` the `/etc/os-release` file is used. The file is copied from
+the container and parsed.
+
 ## Examples
 
 - `x86-64-debian-12`

--- a/example/docker/fleet-os-2/init_toolchain.sh
+++ b/example/docker/fleet-os-2/init_toolchain.sh
@@ -6,7 +6,7 @@ INSTALL_DIR="$1"
 TOOLS_INSTALL_DIR="$2"
 TMP_DIR="/tmp/toolchain-install"
 
-TOOLS_PACKAGE_URI="https://github.com/bringauto/packager/releases/download/v0.3.0/bringauto-packager-tools_v0.3.0_x86-64-linux.zip"
+TOOLS_PACKAGE_URI="https://github.com/bringauto/packager/releases/download/v1.2.0/bringauto-packager-tools_v1.2.0_x86-64-linux.zip"
 TOOLCHAIN_PACKAGE_URI="https://gitlab.bringauto.com/bringauto-public/fleet-os-toolchain/-/raw/add-v2.9.0/fleet-os/v2.9.1/fleet-os-toolchain_v2.9.1_raspberrypi4-64.zip?ref_type=heads"
 
 if [[ ${INSTALL_DIR} = "" ]]

--- a/example/docker/ubuntu1804-aarch64/init_toolchain.sh
+++ b/example/docker/ubuntu1804-aarch64/init_toolchain.sh
@@ -5,7 +5,7 @@ set -e
 TOOLS_INSTALL_DIR="$1"
 TMP_DIR="/tmp/toolchain-install"
 
-TOOLS_PACKAGE_URI="https://github.com/bringauto/packager/releases/download/v0.3.2/bringauto-packager-tools_v0.3.2_x86-64-linux.zip"
+TOOLS_PACKAGE_URI="https://github.com/bringauto/packager/releases/download/v1.2.0/bringauto-packager-tools_v1.2.0_x86-64-linux.zip"
 
 if [[ ${TOOLS_INSTALL_DIR} = "" ]]
 then


### PR DESCRIPTION
- [x] Update version of tools in docker images
- [x] Update doc

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Documentation
  - Clarified platform string construction from machine, distro name, and version; added an arm64-fedora-41 example.
  - Updated OS identification to require /etc/os-release with ID and VERSION_ID; replaced lsb_release-based guidance.
  - Noted host port forwarding is configurable (default 1122) and added uname -m requirement for machine field.

- Chores
  - Updated example Docker toolchain environments to use packager tools v1.2.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->