### PR TITLE
Add integration tests for Meson

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -71,7 +71,6 @@ def test_sysroot():
 def packager_binary():
     """Compile the Go application binary."""
 
-    subprocess.run(["go", "get", "bringauto/cmd/bap-builder"], check=True)
     subprocess.run(
         ["go", "build", "-o", test_config["packager_binary"], "../cmd/bap-builder"],
         check=True,

--- a/tests/integration_tests/test_build_package.py
+++ b/tests/integration_tests/test_build_package.py
@@ -735,3 +735,144 @@ def test_25_invalid_revision(test_image, packager_binary, context, test_repo):
         expected_result=PackagerExpectedResult.FAILURE,
         expected_returncode=PackagerReturnCode.BUILD_ERROR,
     )
+
+def test_26_meson_build(test_image, packager_binary, context, test_repo):
+    """Test building a package using Meson build system."""
+    package = "test_package_10"
+    prepare_packages([package])
+    if not does_package_support_image(package, test_image):
+        return
+
+    run_packager(
+        packager_binary,
+        "build-package",
+        context=context,
+        image_name=test_image,
+        output_dir=test_repo,
+        name=package,
+        expected_result=PackagerExpectedResult.SUCCESS,
+    )
+
+def test_27_cmake_invalid_define(test_image, packager_binary, context, test_repo):
+    """Test building a package with an CMake define with invalid characters."""
+    package = "test_package_1_27"
+    prepare_packages([package])
+
+    run_packager(
+        packager_binary,
+        "build-package",
+        context=context,
+        image_name=test_image,
+        output_dir=test_repo,
+        name=package,
+        expected_result=PackagerExpectedResult.FAILURE,
+        expected_returncode=PackagerReturnCode.CONTEXT_ERROR,
+    )
+
+def test_28_meson_invalid_define(test_image, packager_binary, context, test_repo):
+    """Test building a package with an Meson define with invalid characters."""
+    package = "test_package_10_28"
+    prepare_packages([package])
+    if not does_package_support_image(package, test_image):
+        return
+
+    run_packager(
+        packager_binary,
+        "build-package",
+        context=context,
+        image_name=test_image,
+        output_dir=test_repo,
+        name=package,
+        expected_result=PackagerExpectedResult.FAILURE,
+        expected_returncode=PackagerReturnCode.CONTEXT_ERROR,
+    )
+
+def test_29_meson_invalid_option(test_image, packager_binary, context, test_repo):
+    """Test building a package with an Meson option with invalid characters."""
+    package = "test_package_10_29"
+    prepare_packages([package])
+    if not does_package_support_image(package, test_image):
+        return
+
+    run_packager(
+        packager_binary,
+        "build-package",
+        context=context,
+        image_name=test_image,
+        output_dir=test_repo,
+        name=package,
+        expected_result=PackagerExpectedResult.FAILURE,
+        expected_returncode=PackagerReturnCode.CONTEXT_ERROR,
+    )
+
+def test_30_meson_empty_define(test_image, packager_binary, context, test_repo):
+    """Test building a package with an Meson define with empty name."""
+    package = "test_package_10_30"
+    prepare_packages([package])
+    if not does_package_support_image(package, test_image):
+        return
+
+    run_packager(
+        packager_binary,
+        "build-package",
+        context=context,
+        image_name=test_image,
+        output_dir=test_repo,
+        name=package,
+        expected_result=PackagerExpectedResult.FAILURE,
+        expected_returncode=PackagerReturnCode.CONTEXT_ERROR,
+    )
+
+def test_31_meson_empty_option(test_image, packager_binary, context, test_repo):
+    """Test building a package with an Meson option with empty name."""
+    package = "test_package_10_31"
+    prepare_packages([package])
+    if not does_package_support_image(package, test_image):
+        return
+
+    run_packager(
+        packager_binary,
+        "build-package",
+        context=context,
+        image_name=test_image,
+        output_dir=test_repo,
+        name=package,
+        expected_result=PackagerExpectedResult.FAILURE,
+        expected_returncode=PackagerReturnCode.CONTEXT_ERROR,
+    )
+
+def test_32_cmake_empty_define(test_image, packager_binary, context, test_repo):
+    """Test building a package with an CMake define with empty name."""
+    package = "test_package_1_32"
+    prepare_packages([package])
+    if not does_package_support_image(package, test_image):
+        return
+
+    run_packager(
+        packager_binary,
+        "build-package",
+        context=context,
+        image_name=test_image,
+        output_dir=test_repo,
+        name=package,
+        expected_result=PackagerExpectedResult.FAILURE,
+        expected_returncode=PackagerReturnCode.CONTEXT_ERROR,
+    )
+
+def test_33_cmake_wrong_define_type(test_image, packager_binary, context, test_repo):
+    """Test building a package with an CMake define with non-string value."""
+    package = "test_package_1_33"
+    prepare_packages([package])
+    if not does_package_support_image(package, test_image):
+        return
+
+    run_packager(
+        packager_binary,
+        "build-package",
+        context=context,
+        image_name=test_image,
+        output_dir=test_repo,
+        name=package,
+        expected_result=PackagerExpectedResult.FAILURE,
+        expected_returncode=PackagerReturnCode.CONTEXT_ERROR,
+    )

--- a/tests/integration_tests/test_build_package.py
+++ b/tests/integration_tests/test_build_package.py
@@ -753,6 +753,8 @@ def test_26_meson_build(test_image, packager_binary, context, test_repo):
         expected_result=PackagerExpectedResult.SUCCESS,
     )
 
+    assert is_tracked(package, test_repo, "package")
+
 def test_27_cmake_invalid_define(test_image, packager_binary, context, test_repo):
     """Test building a package with an CMake define with invalid characters."""
     package = "test_package_1_27"

--- a/tests/test_data/test_packages/test_package_10/c_example_debug.json
+++ b/tests/test_data/test_packages/test_package_10/c_example_debug.json
@@ -18,8 +18,8 @@
     "PlatformString": {
       "Mode": "auto"
     },
-    "IsLibrary": false,
-    "IsDevLib": false,
+    "IsLibrary": true,
+    "IsDevLib": true,
     "IsDebug": true
   },
   "DockerMatrix": {

--- a/tests/test_data/test_packages/test_package_10/c_example_debug.json
+++ b/tests/test_data/test_packages/test_package_10/c_example_debug.json
@@ -1,0 +1,32 @@
+{
+  "Env": {},
+  "DependsOn": [],
+  "Git": {
+    "URI": "https://github.com/squidfarts/c-example.git",
+    "Revision": "master"
+  },
+  "Build": {
+    "Meson": {
+      "Options": {
+        "buildtype": "debug"
+      }
+    }
+  },
+  "Package": {
+    "Name": "test_package_10",
+    "VersionTag": "v1.0.0",
+    "PlatformString": {
+      "Mode": "auto"
+    },
+    "IsLibrary": false,
+    "IsDevLib": false,
+    "IsDebug": true
+  },
+  "DockerMatrix": {
+    "ImageNames": [
+      "ubuntu2404",
+      "fedora40",
+      "fedora41"
+    ]
+  }
+}

--- a/tests/test_data/test_packages/test_package_10_28/c_example_debug.json
+++ b/tests/test_data/test_packages/test_package_10_28/c_example_debug.json
@@ -1,0 +1,35 @@
+{
+  "Env": {},
+  "DependsOn": [],
+  "Git": {
+    "URI": "https://github.com/squidfarts/c-example.git",
+    "Revision": "master"
+  },
+  "Build": {
+    "Meson": {
+      "Defines": {
+        "INVALID$DEFINE": "define"
+      },
+      "Options": {
+        "buildtype": "debug"
+      }
+    }
+  },
+  "Package": {
+    "Name": "test_package_10_28",
+    "VersionTag": "v1.0.0",
+    "PlatformString": {
+      "Mode": "auto"
+    },
+    "IsLibrary": false,
+    "IsDevLib": false,
+    "IsDebug": true
+  },
+  "DockerMatrix": {
+    "ImageNames": [
+      "ubuntu2404",
+      "fedora40",
+      "fedora41"
+    ]
+  }
+}

--- a/tests/test_data/test_packages/test_package_10_28/c_example_debug.json
+++ b/tests/test_data/test_packages/test_package_10_28/c_example_debug.json
@@ -21,8 +21,8 @@
     "PlatformString": {
       "Mode": "auto"
     },
-    "IsLibrary": false,
-    "IsDevLib": false,
+    "IsLibrary": true,
+    "IsDevLib": true,
     "IsDebug": true
   },
   "DockerMatrix": {

--- a/tests/test_data/test_packages/test_package_10_29/c_example_debug.json
+++ b/tests/test_data/test_packages/test_package_10_29/c_example_debug.json
@@ -19,8 +19,8 @@
     "PlatformString": {
       "Mode": "auto"
     },
-    "IsLibrary": false,
-    "IsDevLib": false,
+    "IsLibrary": true,
+    "IsDevLib": true,
     "IsDebug": true
   },
   "DockerMatrix": {

--- a/tests/test_data/test_packages/test_package_10_29/c_example_debug.json
+++ b/tests/test_data/test_packages/test_package_10_29/c_example_debug.json
@@ -1,0 +1,33 @@
+{
+  "Env": {},
+  "DependsOn": [],
+  "Git": {
+    "URI": "https://github.com/squidfarts/c-example.git",
+    "Revision": "master"
+  },
+  "Build": {
+    "Meson": {
+      "Options": {
+        "buildtype": "debug",
+        "invalid_option": "option"
+      }
+    }
+  },
+  "Package": {
+    "Name": "test_package_10_29",
+    "VersionTag": "v1.0.0",
+    "PlatformString": {
+      "Mode": "auto"
+    },
+    "IsLibrary": false,
+    "IsDevLib": false,
+    "IsDebug": true
+  },
+  "DockerMatrix": {
+    "ImageNames": [
+      "ubuntu2404",
+      "fedora40",
+      "fedora41"
+    ]
+  }
+}

--- a/tests/test_data/test_packages/test_package_10_30/c_example_debug.json
+++ b/tests/test_data/test_packages/test_package_10_30/c_example_debug.json
@@ -21,8 +21,8 @@
     "PlatformString": {
       "Mode": "auto"
     },
-    "IsLibrary": false,
-    "IsDevLib": false,
+    "IsLibrary": true,
+    "IsDevLib": true,
     "IsDebug": true
   },
   "DockerMatrix": {

--- a/tests/test_data/test_packages/test_package_10_30/c_example_debug.json
+++ b/tests/test_data/test_packages/test_package_10_30/c_example_debug.json
@@ -1,0 +1,35 @@
+{
+  "Env": {},
+  "DependsOn": [],
+  "Git": {
+    "URI": "https://github.com/squidfarts/c-example.git",
+    "Revision": "master"
+  },
+  "Build": {
+    "Meson": {
+      "Defines": {
+        "": "define"
+      },
+      "Options": {
+        "buildtype": "debug"
+      }
+    }
+  },
+  "Package": {
+    "Name": "test_package_10_30",
+    "VersionTag": "v1.0.0",
+    "PlatformString": {
+      "Mode": "auto"
+    },
+    "IsLibrary": false,
+    "IsDevLib": false,
+    "IsDebug": true
+  },
+  "DockerMatrix": {
+    "ImageNames": [
+      "ubuntu2404",
+      "fedora40",
+      "fedora41"
+    ]
+  }
+}

--- a/tests/test_data/test_packages/test_package_10_31/c_example_debug.json
+++ b/tests/test_data/test_packages/test_package_10_31/c_example_debug.json
@@ -1,0 +1,32 @@
+{
+  "Env": {},
+  "DependsOn": [],
+  "Git": {
+    "URI": "https://github.com/squidfarts/c-example.git",
+    "Revision": "master"
+  },
+  "Build": {
+    "Meson": {
+      "Options": {
+        "": "debug"
+      }
+    }
+  },
+  "Package": {
+    "Name": "test_package_10_31",
+    "VersionTag": "v1.0.0",
+    "PlatformString": {
+      "Mode": "auto"
+    },
+    "IsLibrary": false,
+    "IsDevLib": false,
+    "IsDebug": true
+  },
+  "DockerMatrix": {
+    "ImageNames": [
+      "ubuntu2404",
+      "fedora40",
+      "fedora41"
+    ]
+  }
+}

--- a/tests/test_data/test_packages/test_package_10_31/c_example_debug.json
+++ b/tests/test_data/test_packages/test_package_10_31/c_example_debug.json
@@ -18,8 +18,8 @@
     "PlatformString": {
       "Mode": "auto"
     },
-    "IsLibrary": false,
-    "IsDevLib": false,
+    "IsLibrary": true,
+    "IsDevLib": true,
     "IsDebug": true
   },
   "DockerMatrix": {

--- a/tests/test_data/test_packages/test_package_1_27/zlib_release.json
+++ b/tests/test_data/test_packages/test_package_1_27/zlib_release.json
@@ -1,0 +1,35 @@
+{
+  "Env": {},
+  "Git": {
+    "URI": "https://github.com/madler/zlib.git",
+    "Revision": "v1.2.11"
+  },
+  "Build": {
+    "CMake": {
+      "Defines": {
+        "CMAKE_BUILD_TYPE": "Release",
+        "INVALID$DEFINE": "define"
+      }
+    }
+  },
+  "Package": {
+    "Name": "test_package_1_26",
+    "VersionTag": "v1.2.11",
+    "PlatformString": {
+      "Mode": "auto"
+    },
+    "IsLibrary": true,
+    "IsDevLib": true,
+    "IsDebug": false
+  },
+  "DockerMatrix": {
+    "ImageNames": [
+      "fleet-os-2",
+      "debian12",
+      "ubuntu1804-aarch64",
+      "ubuntu2404",
+      "fedora40",
+      "fedora41"
+    ]
+  }
+}

--- a/tests/test_data/test_packages/test_package_1_32/zlib_release.json
+++ b/tests/test_data/test_packages/test_package_1_32/zlib_release.json
@@ -1,0 +1,34 @@
+{
+  "Env": {},
+  "Git": {
+    "URI": "https://github.com/madler/zlib.git",
+    "Revision": "v1.2.11"
+  },
+  "Build": {
+    "CMake": {
+      "Defines": {
+        "": "Release"
+      }
+    }
+  },
+  "Package": {
+    "Name": "test_package_1_33",
+    "VersionTag": "v1.2.11",
+    "PlatformString": {
+      "Mode": "auto"
+    },
+    "IsLibrary": true,
+    "IsDevLib": true,
+    "IsDebug": false
+  },
+  "DockerMatrix": {
+    "ImageNames": [
+      "fleet-os-2",
+      "debian12",
+      "ubuntu1804-aarch64",
+      "ubuntu2404",
+      "fedora40",
+      "fedora41"
+    ]
+  }
+}

--- a/tests/test_data/test_packages/test_package_1_33/zlib_release.json
+++ b/tests/test_data/test_packages/test_package_1_33/zlib_release.json
@@ -1,0 +1,35 @@
+{
+  "Env": {},
+  "Git": {
+    "URI": "https://github.com/madler/zlib.git",
+    "Revision": "v1.2.11"
+  },
+  "Build": {
+    "CMake": {
+      "Defines": {
+        "CMAKE_BUILD_TYPE": "Release",
+        "SOME_DEFINE": true
+      }
+    }
+  },
+  "Package": {
+    "Name": "test_package_1_35",
+    "VersionTag": "v1.2.11",
+    "PlatformString": {
+      "Mode": "auto"
+    },
+    "IsLibrary": true,
+    "IsDevLib": true,
+    "IsDebug": false
+  },
+  "DockerMatrix": {
+    "ImageNames": [
+      "fleet-os-2",
+      "debian12",
+      "ubuntu1804-aarch64",
+      "ubuntu2404",
+      "fedora40",
+      "fedora41"
+    ]
+  }
+}


### PR DESCRIPTION
Add integration test for Meson build system and some wrong defines/options for both CMake and Meson.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded test suite with eight new cases covering Meson and CMake builds, including validations for invalid/empty defines, invalid options, wrong types, and a successful Meson debug build.
  * Added multiple new test data package configurations to exercise these scenarios.

* **Chores**
  * Simplified test build setup by removing an intermediate external fetch step prior to building the test binary.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->