### PR TITLE
No checkout after clone

### DIFF
--- a/internal/git/Git.go
+++ b/internal/git/Git.go
@@ -36,7 +36,7 @@ func (args *GitClone) ConstructCMDLine() []string {
 	cmd := []string{
 		GitExecutablePath,
 		"clone",
-		"--recursive",
+		"--no-checkout",
 		args.URI,
 		args.ClonePath,
 	}

--- a/internal/git/default_test.go
+++ b/internal/git/default_test.go
@@ -16,7 +16,7 @@ func TestGitClone_ConstructCMDLine(t *testing.T) {
 	validCmdLine := []string{
 		git.GitExecutablePath,
 		"clone",
-		"--recursive",
+		"--no-checkout",
 		gitClone.URI,
 		gitClone.ClonePath,
 	}


### PR DESCRIPTION
I have two branches BRANCH_A and BRANCH_MODULES, where BRANCH_A does not contain git submodules, and BRANCH_MODULES has several private/unaccessible submodules for the user who tries to access them.

Let BRANCH_MODULES be set up as the default git branch. Then Packager fails with "Cannot access" because it clones whole repository by the standard `git clone`, which checks out to the default branch (BRANCH_MODULES) and then to a BRANCH_A

I suggest adding option `--no-checkout` t ogit clone.

```json
"Git": {
    "URI": "<nice_uri>",
    "Revision": "BRANCH_A"
  }
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Modified repository cloning behavior to skip automatic working-tree checkout during clone operations.
  * Clones now preserve an uninitialized working state after download, allowing callers to perform checkout or initialization steps explicitly when needed.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->