### PR TITLE
Add check for missing --name or --all options + integration test

### DIFF
--- a/cmd/bap-builder/CmdArgs.go
+++ b/cmd/bap-builder/CmdArgs.go
@@ -293,6 +293,24 @@ func (cmd *CmdLineArgs) ParseArgs(args []string) error {
 	cmd.BuildApp = cmd.buildAppParser.Happened()
 	cmd.CreateSysroot = cmd.createSysrootParser.Happened()
 
+	return cmd.checkInvalidOptionCombinations()
+}
+
+// checkInvalidOptionCombinations
+// Return appropriate error when any invalid option combination is detected, else nil.
+func (cmd *CmdLineArgs) checkInvalidOptionCombinations() error {
+	if cmd.BuildPackage {
+		if *cmd.BuildPackageArgs.Name == "" && !*cmd.BuildPackageArgs.All {
+			return fmt.Errorf("build-package requires either --name or --all")
+		}
+	}
+
+	if cmd.BuildApp {
+		if *cmd.BuildAppArgs.Name == "" && !*cmd.BuildAppArgs.All {
+			return fmt.Errorf("build-app requires either --name or --all")
+		}
+	}
+
 	if *cmd.BuildPackageArgs.All {
 		if *cmd.BuildPackageArgs.BuildDeps {
 			return fmt.Errorf("all and build-deps flags at the same time")

--- a/tests/integration_tests/test_invalid_arguments.py
+++ b/tests/integration_tests/test_invalid_arguments.py
@@ -75,3 +75,35 @@ def test_05_run_with_nonexisting_app(test_image, packager_binary, test_repo, con
     stdout = result.communicate()[0]
 
     assert "ERROR" in stdout
+
+
+def test_06_build_package_without_name_or_all(test_image, packager_binary, context, test_repo):
+    """Run build-package without --name or --all"""
+
+    result = run_packager(
+        packager_binary,
+        "build-package",
+        context=context,
+        image_name=test_image,
+        output_dir=test_repo,
+        expected_returncode=PackagerReturnCode.CMD_LINE_ERROR,
+    )
+    stdout = result.communicate()[0]
+
+    assert "ERROR" in stdout
+
+
+def test_07_build_app_without_name_or_all(test_image, packager_binary, context, test_repo):
+    """Run build-app without --name or --all"""
+
+    result = run_packager(
+        packager_binary,
+        "build-app",
+        context=context,
+        image_name=test_image,
+        output_dir=test_repo,
+        expected_returncode=PackagerReturnCode.CMD_LINE_ERROR,
+    )
+    stdout = result.communicate()[0]
+
+    assert "ERROR" in stdout


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced command-line argument validation for `build-package` and `build-app` commands.
  * Tool now requires either `--name` or `--all` flags to be specified.
  * Improved error messages for invalid argument combinations.

* **Tests**
  * Added integration tests to verify argument validation behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bacpack-system/packager/pull/53)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->